### PR TITLE
Add shebang

### DIFF
--- a/scripts/VOTCARC.bash.in
+++ b/scripts/VOTCARC.bash.in
@@ -1,4 +1,5 @@
-# 
+#!/usr/bin/env bash
+#
 # Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/VOTCARC.bash.in
+++ b/scripts/VOTCARC.bash.in
@@ -31,7 +31,7 @@ for rc in "@CMAKE_INSTALL_PREFIX@/@DATA@"/rc/*rc.bash; do
 done
 unset rc
 
-#bash cmopletion
+#bash completion
 if [ -n "$BASH_VERSION" ]; then 
   for comp in "@CMAKE_INSTALL_PREFIX@/@DATA@"/rc/*completion.bash; do
     [ -r "$comp" ] && source "$comp"

--- a/scripts/VOTCARC.csh.in
+++ b/scripts/VOTCARC.csh.in
@@ -1,4 +1,5 @@
-# 
+#!/usr/bin/env csh
+#
 # Copyright 2009-2011 The VOTCA Development Team (http://www.votca.org)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR fixes a small typo in `VOTCARC.bash` and adds shebangs to the scripts in `/usr/bin`.

Even though these scripts are supposed to be 'sourced' and not run anyway, the shebangs don't hurt and avoid a failure, when e.g. running /usr/bin/VOTCARC.csh in bash.