### PR TITLE
Name object

### DIFF
--- a/include/votca/tools/name.h
+++ b/include/votca/tools/name.h
@@ -1,0 +1,56 @@
+/*
+ *            Copyright 2009-2018 The VOTCA Development Team
+ *                       (http://www.votca.org)
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *              http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef _VOTCA_TOOLS_NAME_H
+#define _VOTCA_TOOLS_NAME_H
+
+#include <string>
+#include <exception>
+
+namespace votca {
+namespace tools {
+
+/**
+ * \brief Name object
+ *
+ * This object is meant to be used a derived type for larger objects. In this
+ * way the same methods for setting and getting the name of an object will be
+ * uniformly defined.
+ *
+ */
+class Name {
+ private:
+  std::string name_{""};
+  bool name_set_{false};
+
+ public:
+  Name() {};
+  Name(const std::string name) : name_(name), name_set_(true) {};
+  void setName(const std::string name) {
+    name_ = name;
+    name_set_ = true;
+  }
+  std::string getName() {
+    return (!name_set_ ? throw std::runtime_error("Name not set") : name_);
+  }
+};
+}
+}
+
+#endif  // _VOTCA_TOOLS_NAME_H

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Boost 1.39.0 REQUIRED COMPONENTS unit_test_framework)
-foreach(PROG test_elements test_edge )
+foreach(PROG test_elements test_edge test_name )
   file(GLOB ${PROG}_SOURCES ${PROG}*.cc)
   add_executable(unit_${PROG} ${${PROG}_SOURCES})
   target_link_libraries(unit_${PROG} votca_tools ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})

--- a/src/tests/test_name.cc
+++ b/src/tests/test_name.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE name_test
+#include <boost/test/unit_test.hpp>
+#include <exception>
+#include <string>
+#include <votca/tools/name.h>
+
+using namespace std;
+using namespace votca::tools;
+
+BOOST_AUTO_TEST_SUITE(name_test)
+
+BOOST_AUTO_TEST_CASE(constructors_test) {
+  Name nm;
+  Name nm2("S");
+}
+
+BOOST_AUTO_TEST_CASE(accessors_test) {
+  Name nm;
+  BOOST_CHECK_THROW(nm.getName(), runtime_error);
+  nm.setName("New Name");
+  BOOST_CHECK_EQUAL(nm.getName(), "New Name");
+  Name nm2("Name2");
+  BOOST_CHECK_EQUAL(nm2.getName(), "Name2");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Designed to used in larger objects across votca should provide uniform methods for setting and getting object names. 