### PR TITLE
removed use of boost namespace

### DIFF
--- a/src/libtools/edgecontainer.cc
+++ b/src/libtools/edgecontainer.cc
@@ -23,11 +23,9 @@
 #include <votca/tools/edge.h>
 #include <votca/tools/edgecontainer.h>
 #include <algorithm>
-#include <boost/lexical_cast.hpp>
 
 using namespace votca::tools;
 using namespace std;
-using namespace boost;
 
 EdgeContainer::EdgeContainer(Edge ed) { addEdge(ed); }
 
@@ -40,8 +38,8 @@ EdgeContainer::EdgeContainer(vector<Edge> eds) {
 int EdgeContainer::getMaxDegree(void){
   int max = 0;
   for(auto const& it : adj_list_) {
-    if(it.second.size()>lexical_cast<size_t>(max)) {
-      max = lexical_cast<int>(it.second.size());
+    if(it.second.size()>static_cast<size_t>(max)) {
+      max = static_cast<int>(it.second.size());
     }
   }
   return max;
@@ -49,13 +47,13 @@ int EdgeContainer::getMaxDegree(void){
 
 int EdgeContainer::getDegree(int vert){
   if(!adj_list_.count(vert)) throw invalid_argument("vertex is not defined");
-  return lexical_cast<int>(adj_list_[vert].size());
+  return static_cast<int>(adj_list_[vert].size());
 }
 
 vector<int> EdgeContainer::getVerticesDegree(int degree){
   vector<int> verts;
   for(auto v_list : adj_list_){
-    if(lexical_cast<int>(v_list.second.size())==degree){
+    if(static_cast<int>(v_list.second.size())==degree){
       verts.push_back(v_list.first);
     }
   }

--- a/src/tests/test_table.cc
+++ b/src/tests/test_table.cc
@@ -56,14 +56,14 @@ BOOST_AUTO_TEST_CASE(xy_test) {
   for (int i = 0; i < 10; ++i) {
     int x = i;
     int y = 2 * x;
-    BOOST_CHECK_EQUAL(boost::lexical_cast<int>(x_v(i)),
-                      boost::lexical_cast<int>(tb.x(i)));
-    BOOST_CHECK_EQUAL(boost::lexical_cast<int>(y_v(i)),
-                      boost::lexical_cast<int>(tb.y(i)));
-    BOOST_CHECK_EQUAL(x, boost::lexical_cast<int>(tb.x(i)));
-    BOOST_CHECK_EQUAL(y, boost::lexical_cast<int>(tb.y(i)));
-    BOOST_CHECK_EQUAL(x, boost::lexical_cast<int>(x_v(i)));
-    BOOST_CHECK_EQUAL(y, boost::lexical_cast<int>(y_v(i)));
+    BOOST_CHECK_EQUAL(static_cast<int>(x_v(i)),
+                      static_cast<int>(tb.x(i)));
+    BOOST_CHECK_EQUAL(static_cast<int>(y_v(i)),
+                      static_cast<int>(tb.y(i)));
+    BOOST_CHECK_EQUAL(x, static_cast<int>(tb.x(i)));
+    BOOST_CHECK_EQUAL(y, static_cast<int>(tb.y(i)));
+    BOOST_CHECK_EQUAL(x, static_cast<int>(x_v(i)));
+    BOOST_CHECK_EQUAL(y, static_cast<int>(y_v(i)));
   }
 }
 
@@ -74,10 +74,10 @@ BOOST_AUTO_TEST_CASE(getMinMax_test) {
     tb.push_back(x, y);
   }
   
-  BOOST_CHECK_EQUAL(boost::lexical_cast<int>(tb.getMinX()), 0);
-  BOOST_CHECK_EQUAL(boost::lexical_cast<int>(tb.getMaxX()), 9);
-  BOOST_CHECK_EQUAL(boost::lexical_cast<int>(tb.getMinY()), 0);
-  BOOST_CHECK_EQUAL(boost::lexical_cast<int>(tb.getMaxY()), 18);
+  BOOST_CHECK_EQUAL(static_cast<int>(tb.getMinX()), 0);
+  BOOST_CHECK_EQUAL(static_cast<int>(tb.getMaxX()), 9);
+  BOOST_CHECK_EQUAL(static_cast<int>(tb.getMinY()), 0);
+  BOOST_CHECK_EQUAL(static_cast<int>(tb.getMaxY()), 18);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I did not realize I was misusing lexical cast until Victor pointed it out with the matrix pull request. Then I remembered I had used it elsewhere for converting between types where I should of simply used static_cast  seeing as I was not converting between strings. 