### PR TITLE
Fixed memory error

### DIFF
--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -18,6 +18,7 @@
  */
 
 #include <algorithm>
+#include <cassert>
 #include <string>
 #include <votca/tools/graph.h>
 
@@ -106,7 +107,10 @@ void Graph::setNode(std::pair<int, GraphNode> p_gn) {
   setNode(p_gn.first, p_gn.second);
 }
 
-GraphNode Graph::getNode(int vert) { return nodes_[vert]; }
+GraphNode Graph::getNode(int vert) { 
+  assert(nodes_.count(vert));
+  return nodes_[vert]; 
+}
 
 vector<pair<int, GraphNode>> Graph::getNodes(void) {
   vector<pair<int, GraphNode>> vec_nodes;

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -77,18 +77,21 @@ vector<shared_ptr<Graph>> decoupleIsolatedSubGraphs(Graph g) {
     ++v_it;
     auto sub_graph_explored_vertices = gv_breadth_first.getExploredVertices();
     set<Edge> sub_graph_edges;
-    for (auto sub_graph_vertex : sub_graph_explored_vertices) {
-      if (*v_it == sub_graph_vertex) {
+
+    auto sub_graph_vertex_it = sub_graph_explored_vertices.begin();
+    while(sub_graph_vertex_it!=sub_graph_explored_vertices.end()) {
+      if (*v_it == *sub_graph_vertex_it) {
         ++v_it;
       }
-      vertices_list.remove(sub_graph_vertex);
+      vertices_list.remove(*sub_graph_vertex_it);
 
-      auto sub_graph_neigh_edges = g.getNeighEdges(sub_graph_vertex);
+      auto sub_graph_neigh_edges = g.getNeighEdges(*sub_graph_vertex_it);
       for (auto sub_graph_edge : sub_graph_neigh_edges) {
         sub_graph_edges.insert(sub_graph_edge);
       }
 
-      sub_graph_nodes[sub_graph_vertex] = g.getNode(sub_graph_vertex);
+      sub_graph_nodes[*sub_graph_vertex_it] = g.getNode(*sub_graph_vertex_it);
+      ++sub_graph_vertex_it;
     }
 
     auto sub_graph_vector_edges = edgeSetToVector_(sub_graph_edges);

--- a/src/tests/test_graph_bf_visitor.cc
+++ b/src/tests/test_graph_bf_visitor.cc
@@ -109,12 +109,14 @@ BOOST_AUTO_TEST_CASE(basic_test2) {
   GraphNode gn2;
   GraphNode gn3;
   GraphNode gn4;
+  GraphNode gn5;
 
   unordered_map<int, GraphNode> nodes;
   nodes[0] = gn1;
   nodes[1] = gn2;
   nodes[2] = gn3;
   nodes[3] = gn4;
+  nodes[4] = gn5;
 
   Graph g(edges, nodes);
 

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
     gb_v2.setStartingVertex(2);
     BOOST_CHECK_THROW(singleNetwork(g, gb_v2), invalid_argument);
   }
-/*
+
   {
 
     // In this test we add 3 nodes but only one edge
@@ -105,9 +105,9 @@ BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
     bool single_n = singleNetwork(g, gb_v);
     BOOST_CHECK(!single_n);
     BOOST_CHECK(gb_v.queEmpty());
-  }*/
+  }
 }
-/*
+
 BOOST_AUTO_TEST_CASE(decoupleIsolatedSubGraphs_algorithm_test) {
   {
     // In this test we add two nodes and an edge describing
@@ -268,5 +268,5 @@ BOOST_AUTO_TEST_CASE(structureid_test) {
     BOOST_CHECK_EQUAL(structId, answer);
   }
 }
-*/
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -37,6 +37,7 @@ using namespace boost::unit_test;
 
 BOOST_AUTO_TEST_SUITE(graphalgorithm_test)
 
+
 BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
   {
     // In this test we add two nodes and an edge describing
@@ -71,7 +72,7 @@ BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
     gb_v2.setStartingVertex(2);
     BOOST_CHECK_THROW(singleNetwork(g, gb_v2), invalid_argument);
   }
-
+/*
   {
 
     // In this test we add 3 nodes but only one edge
@@ -104,9 +105,9 @@ BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
     bool single_n = singleNetwork(g, gb_v);
     BOOST_CHECK(!single_n);
     BOOST_CHECK(gb_v.queEmpty());
-  }
+  }*/
 }
-
+/*
 BOOST_AUTO_TEST_CASE(decoupleIsolatedSubGraphs_algorithm_test) {
   {
     // In this test we add two nodes and an edge describing
@@ -178,7 +179,6 @@ BOOST_AUTO_TEST_CASE(decoupleIsolatedSubGraphs_algorithm_test) {
     nodes[6] = gn7;
 
     Graph g(edges, nodes);
-
     vector<std::shared_ptr<Graph>> sub_graphs = decoupleIsolatedSubGraphs(g);
     BOOST_CHECK_EQUAL(sub_graphs.size(), 2);
 
@@ -268,4 +268,5 @@ BOOST_AUTO_TEST_CASE(structureid_test) {
     BOOST_CHECK_EQUAL(structId, answer);
   }
 }
+*/
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Error was caused from using a for range loop with a vector while also skipping vertices occasionally. The for loop was not ending correctly and thus was trying to access memory outside of the vector memory block. 

Fix #60 