### PR TITLE
Refactor name class

### DIFF
--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -24,7 +24,6 @@
 #include <vector>
 #include <votca/tools/edgecontainer.h>
 #include <votca/tools/graphnode.h>
-#include <votca/tools/name.h>
 
 #ifndef _VOTCA_TOOLS_GRAPH_H
 #define _VOTCA_TOOLS_GRAPH_H

--- a/include/votca/tools/graphnode.h
+++ b/include/votca/tools/graphnode.h
@@ -21,7 +21,6 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
-#include <votca/tools/name.h>
 
 #ifndef _VOTCA_TOOLS_GRAPHNODE_H
 #define _VOTCA_TOOLS_GRAPHNODE_H

--- a/include/votca/tools/name.h
+++ b/include/votca/tools/name.h
@@ -42,7 +42,7 @@ class Name {
  public:
   Name() {};
   Name(const std::string name) : name_(name), name_set_(true) {};
-  void setName(const std::string name) {
+  void setName(const std::string &name) {
     name_ = name;
     name_set_ = true;
   }

--- a/include/votca/tools/name.h
+++ b/include/votca/tools/name.h
@@ -36,7 +36,7 @@ namespace tools {
  */
 class Name {
  private:
-  std::string name_{""};
+  std::string name_;
   bool name_set_{false};
 
  public:
@@ -46,8 +46,9 @@ class Name {
     name_ = name;
     name_set_ = true;
   }
-  std::string getName() {
-    return (!name_set_ ? throw std::runtime_error("Name not set") : name_);
+  const std::string &getName() const {
+    if(!name_set_) throw std::runtime_error("Name not set");
+    return name_;
   }
 };
 }


### PR DESCRIPTION
Reducing differences between the setName and getName functions found in most of the structures. References are also supposed to yield better performance. 