### PR TITLE
added constructors conversion functions and tests

### DIFF
--- a/include/votca/tools/matrix.h
+++ b/include/votca/tools/matrix.h
@@ -41,6 +41,15 @@ class matrix {
   matrix(const double &v) { *this = v; }
   matrix(const matrix &m) { *this = m; }
   matrix(double arr[9]) { *this = arr; }
+  
+  matrix(const Eigen::Matrix3d& mat){
+        // clang-format off
+        _m[0]=mat(0,0); _m[1]=mat(0,1); _m[2]=mat(0,2);
+        _m[3]=mat(1,0); _m[4]=mat(1,1); _m[5]=mat(1,2);
+        _m[6]=mat(2,0); _m[7]=mat(2,1); _m[8]=mat(2,2);
+    // clang-format on
+  }
+  
   matrix(const vec &a, const vec &b, const vec &c) {
     // clang-format off
         _m[0]=a.getX(); _m[1]=b.getX(); _m[2]=c.getX();
@@ -87,6 +96,8 @@ class matrix {
     for (size_t i = 0; i < 9; ++i) _m[i] += v._m[i];
     return *this;
   }
+  
+  Eigen::Matrix3d ToEigenMatrix()const;
 
   /**
    * \brief initialize the matrix with zeros
@@ -271,6 +282,16 @@ inline matrix &matrix::operator=(const matrix &m) {
 inline matrix &matrix::operator=(double arr[9]) {
   for (size_t i = 0; i < 9; ++i) _m[i] = arr[i];
   return *this;
+}
+
+inline Eigen::Matrix3d matrix::ToEigenMatrix()const{
+    Eigen::Matrix3d mat=Eigen::Matrix3d::Zero();
+    // clang-format off
+     mat(0,0)=_m[0]; mat(0,1)=_m[1]; mat(0,2)=_m[2];
+     mat(1,0)=_m[3]; mat(1,1)=_m[4]; mat(1,2)=_m[5];
+     mat(2,0)=_m[6]; mat(2,1)=_m[7]; mat(2,2)=_m[8];
+     // clang-format on
+     return mat;
 }
 
 inline void matrix::UnitMatrix() {

--- a/include/votca/tools/vec.h
+++ b/include/votca/tools/vec.h
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <string>
 #include <votca/tools/floatingpointcomparison.h>
+#include <votca/tools/eigen.h>
 #include "tokenizer.h"
 
 namespace votca { namespace tools {
@@ -46,6 +47,9 @@ public:
     vec(const double r[3]);
     vec(const double x, const double y, const double z);
     vec(const std::string &str);
+    vec(const Eigen::Vector3d &vec);
+    
+    Eigen::Vector3d toEigen()const;
     
     
     double operator[](std::size_t i) const;
@@ -175,6 +179,20 @@ inline vec::vec(const std::string &str)
     {
         throw std::runtime_error("\n\n\t error, string to vec, can't convert string to double\n\n");
     }
+}
+
+inline vec::vec(const Eigen::Vector3d &vec){
+    for (int i=0;i<3;i++){
+        xyz[i]=vec[i];
+    }
+}
+
+inline Eigen::Vector3d vec::toEigen() const{
+    Eigen::Vector3d result;
+    for (int i=0;i<3;i++){
+        result[i]=xyz[i];
+    }
+    return result;
 }
 
 inline vec::vec(const double x, const double y, const double z)

--- a/src/tests/test_matrix.cc
+++ b/src/tests/test_matrix.cc
@@ -28,7 +28,6 @@ using namespace votca::tools;
 BOOST_AUTO_TEST_SUITE(matrix_test)
 
 BOOST_AUTO_TEST_CASE(constructors_test) {
-  matrix mat;
   vec v1(1,2,3);
   vec v2(4,5,6);
   vec v3(7,8,9);
@@ -37,6 +36,18 @@ BOOST_AUTO_TEST_CASE(constructors_test) {
   matrix mat4 = mat2;
   std::cout<<"mat2"<< mat2 << std::endl;
   std::cout<<"mat4"<< mat4 << std::endl;
+}
+
+BOOST_AUTO_TEST_CASE(eigen_test) {
+  vec v1(1,2,3);
+  vec v2(4,5,6);
+  vec v3(7,8,9);
+  matrix mat(v1,v2,v3);
+  matrix mat2(mat.ToEigenMatrix());
+          
+  BOOST_CHECK(mat.isClose(mat2,0.01));
+  std::cout<<"mat"<< mat << std::endl;
+  std::cout<<"mat eigen"<<mat.ToEigenMatrix() << std::endl;
 }
 
 BOOST_AUTO_TEST_CASE(overloadoperator_test) {

--- a/src/tests/test_vec.cc
+++ b/src/tests/test_vec.cc
@@ -39,6 +39,19 @@ BOOST_AUTO_TEST_CASE(overloadoperator_test) {
     BOOST_CHECK(!v1.isClose(v3,0.001)); 
   }
 
+BOOST_AUTO_TEST_CASE(Eigenconv_test) {
+
+  vec v1(1,0,0);
+  Eigen::Vector3d unit=Eigen::Vector3d::UnitX();
+ 
+  Eigen::Vector3d conv=vec(unit).toEigen();
+  
+    BOOST_CHECK(v1.toEigen().isApprox(unit,0.001)); 
+    
+    BOOST_CHECK(conv.isApprox(unit,0.0001)); 
+  }
+
+
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
A small interface from tools::matrix to Eigen::Matrix3d and back, same also for vec to Eigen::Vector3d. It is all done by copy. No fancy unions or so, because it is only a temporary solution till we fully switch to Eigen structures and this keeps the ownership clean