### PR TITLE
Feature explore branch algorithm

### DIFF
--- a/include/votca/tools/edge.h
+++ b/include/votca/tools/edge.h
@@ -59,7 +59,7 @@ class Edge {
    * If both ends of the edge point to the same vertex than it is considered a
    * loop.
    **/
-  bool loop() { return vertices_.front() == vertices_.back(); }
+  bool loop() const { return vertices_.front() == vertices_.back(); }
 
   /// Determine if the edge contains the int ID
   bool contains(int ID) const;

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -124,6 +124,7 @@ class Graph {
   virtual int getDegree(int vertex) { return edge_container_.getDegree(vertex); }
   virtual std::vector<int> getVerticesDegree(int degree) { return edge_container_.getVerticesDegree(degree); }
 
+  bool edgeExist(Edge ed) { return edge_container_.edgeExist(ed); }
   bool vertexExist(int vertex) { return edge_container_.vertexExist(vertex);}
   friend std::ostream& operator<<(std::ostream& os, const Graph g);
 };

--- a/include/votca/tools/graph_bf_visitor.h
+++ b/include/votca/tools/graph_bf_visitor.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -49,7 +49,7 @@ class Graph_BF_Visitor : public GraphVisitor {
 
  public:
   Graph_BF_Visitor(){};
-  bool queEmpty();
+  bool queEmpty() const;
 };
 }  // namespace tools
 }  // namespace votca

--- a/include/votca/tools/graph_df_visitor.h
+++ b/include/votca/tools/graph_df_visitor.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -48,8 +48,8 @@ class Graph_DF_Visitor : public GraphVisitor {
 
  public:
   Graph_DF_Visitor(){};
-  bool queEmpty();
+  bool queEmpty() const;
 };
-}
-}
+}  // namespace tools
+}  // namespace votca
 #endif  // __VOTCA_TOOLS_GRAPH_DF_VISITOR_H

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -59,6 +59,35 @@ bool singleNetwork(Graph graph, GraphVisitor& graph_visitor);
  *
  * The `edge` is used to determine which branch is to be explored. The edge must
  * be an edge connected to the starting_vertex.
+ *
+ * Take the following
+ *
+ * 1 - 2 - 3 - 4 - 5
+ *         |       |
+ *         6 - 7 - 8
+ *
+ * If our graph is reprsented by the above depiction and vertex 3 is chosen as
+ * our starting vertex, we are left with 3 edges to choose from Edges:
+ * 
+ *   2 - 3
+ *   3 - 4
+ *   3 - 6
+ *
+ * If we pick edge 3 - 4 or 3 - 6 the returned set of edges will consist of the
+ * loop
+ *
+ *         3 - 4 - 5
+ *         |       |
+ *         6 - 7 - 8
+ *
+ * If instead Edge 2 - 3 is picked, the following set of edges would be returned
+ *
+ * 1 - 2 - 3  
+ *                  
+ * @param[in] - Graph instance 
+ * @param[in] - int starting vertex, where the exploration begins
+ * @param[in] - the edge indicating which branch is to be explored
+ * @return - set of edges in the branch that were explored
  **/
 std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge);
 

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -51,7 +51,7 @@ class GraphVisitor;
  * @param[in,out] - Graph visitor reference instance used to explore the graph
  * @return - Boolean value (true - if single network)
  */
-bool singleNetwork(Graph graph, GraphVisitor& graph_visitor);
+bool singleNetwork(Graph& graph, GraphVisitor& graph_visitor);
 
 /**
  * \brief Explore one of the branches if exploration is initiated at vertex
@@ -89,7 +89,8 @@ bool singleNetwork(Graph graph, GraphVisitor& graph_visitor);
  * @param[in] - the edge indicating which branch is to be explored
  * @return - set of edges in the branch that were explored
  **/
-std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge);
+std::set<Edge> exploreBranch(Graph& g, const int starting_vertex,
+                             const Edge& edge);
 
 /**
  * \brief Will take a graph and reduce it, by removing all vertices with degree

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -53,6 +53,15 @@ class GraphVisitor;
 bool singleNetwork(Graph g, GraphVisitor& gv);
 
 /**
+ * \brief Explore one of the branches if exploration is initiated at vertex
+ * `starting_vertex`.
+ *
+ * The `edge` is used to determine which branch is to be explored. The edge must
+ * be an edge connected to the starting_vertex.
+ **/
+std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge);
+
+/**
  * \brief Break graph into smaller graph instances if the network is made up of
  *        isolated sub networks
  *

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -68,7 +68,7 @@ bool singleNetwork(Graph graph, GraphVisitor& graph_visitor);
  *
  * If our graph is reprsented by the above depiction and vertex 3 is chosen as
  * our starting vertex, we are left with 3 edges to choose from Edges:
- * 
+ *
  *   2 - 3
  *   3 - 4
  *   3 - 6
@@ -82,9 +82,9 @@ bool singleNetwork(Graph graph, GraphVisitor& graph_visitor);
  *
  * If instead Edge 2 - 3 is picked, the following set of edges would be returned
  *
- * 1 - 2 - 3  
- *                  
- * @param[in] - Graph instance 
+ * 1 - 2 - 3
+ *
+ * @param[in] - Graph instance
  * @param[in] - int starting vertex, where the exploration begins
  * @param[in] - the edge indicating which branch is to be explored
  * @return - set of edges in the branch that were explored

--- a/include/votca/tools/graphdistvisitor.h
+++ b/include/votca/tools/graphdistvisitor.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -51,14 +51,14 @@ class Graph_BF_Visitor;
 
 class GraphDistVisitor : public Graph_BF_Visitor {
 
-  public:
-    GraphDistVisitor(){};
+ public:
+  GraphDistVisitor(){};
 
-    /// Note the only manipulation to the BF visitor is the need to add a
-    /// distance attribute to each of the graph nodes.
-    void exploreNode(std::pair<int, GraphNode> &p_gn, Graph& g,
-        Edge ed = DUMMY_EDGE);
+  /// Note the only manipulation to the BF visitor is the need to add a
+  /// distance attribute to each of the graph nodes.
+  void exploreNode(std::pair<int, GraphNode>& p_gn, Graph& g,
+                   Edge ed = DUMMY_EDGE);
 };
-}
-}
+}  // namespace tools
+}  // namespace votca
 #endif  // __VOTCA_TOOLS_GRAPH_DIST_VISITOR_H

--- a/include/votca/tools/graphdistvisitor.h
+++ b/include/votca/tools/graphdistvisitor.h
@@ -53,7 +53,7 @@ class GraphDistVisitor : public Graph_BF_Visitor {
 
   /// Note the only manipulation to the BF visitor is the need to add a
   /// distance attribute to each of the graph nodes.
-  void exploreNode_(std::pair<int, GraphNode> &p_gn, Graph& g,
+  void exploreNode(std::pair<int, GraphNode> &p_gn, Graph& g,
                     Edge ed = DUMMY_EDGE);
 
   public:

--- a/include/votca/tools/graphdistvisitor.h
+++ b/include/votca/tools/graphdistvisitor.h
@@ -51,13 +51,13 @@ class Graph_BF_Visitor;
 
 class GraphDistVisitor : public Graph_BF_Visitor {
 
-  /// Note the only manipulation to the BF visitor is the need to add a
-  /// distance attribute to each of the graph nodes.
-  void exploreNode(std::pair<int, GraphNode> &p_gn, Graph& g,
-                    Edge ed = DUMMY_EDGE);
-
   public:
     GraphDistVisitor(){};
+
+    /// Note the only manipulation to the BF visitor is the need to add a
+    /// distance attribute to each of the graph nodes.
+    void exploreNode(std::pair<int, GraphNode> &p_gn, Graph& g,
+        Edge ed = DUMMY_EDGE);
 };
 }
 }

--- a/include/votca/tools/graphvisitor.h
+++ b/include/votca/tools/graphvisitor.h
@@ -60,7 +60,7 @@ class GraphVisitor {
   virtual Edge getEdge_(Graph g);
   /// Edge(0,0) is a dummy value
  public:
-  virtual void exploreNode_(std::pair<int, GraphNode> &p_gn, Graph& g,
+  virtual void exploreNode(std::pair<int, GraphNode> &p_gn, Graph& g,
                             Edge ed = DUMMY_EDGE);
 
   GraphVisitor() {};

--- a/include/votca/tools/graphvisitor.h
+++ b/include/votca/tools/graphvisitor.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -61,20 +61,20 @@ class GraphVisitor {
   /// Edge(0,0) is a dummy value
  public:
   virtual void exploreNode(std::pair<int, GraphNode>& vertex_and_node,
-                            Graph& graph, Edge edge = DUMMY_EDGE);
+                           Graph& graph, Edge edge = DUMMY_EDGE);
 
   GraphVisitor(){};
 
   /// Determine which vertices in the edge, if any, have not been explored
-  std::vector<int> getUnexploredVertex(Edge edge);
+  std::vector<int> getUnexploredVertex(const Edge edge) const;
 
   /// Determine if the exploration is complete, this is determined by whether
   /// the edge queue is empty or not, it does not necessarily mean all
   /// vertices in a graph have been explored.
-  virtual bool queEmpty();
+  virtual bool queEmpty() const;
 
   void setStartingVertex(int vertex) { startingVertex_ = vertex; }
-  int getStartingVertex() { return startingVertex_; }
+  int getStartingVertex() const { return startingVertex_; }
 
   /// Initialize the graphvisitor the default starting point is 0
   void initialize(Graph& graph);
@@ -90,10 +90,10 @@ class GraphVisitor {
   Edge nextEdge(Graph graph);
 
   /// Get the set of all the vertices that have been explored
-  std::set<int> getExploredVertices();
+  std::set<int> getExploredVertices() const;
 
   /// Has the vertex been explored
-  bool vertexExplored(int vert);
+  bool vertexExplored(const int vert) const;
 };
 }  // namespace tools
 }  // namespace votca

--- a/include/votca/tools/graphvisitor.h
+++ b/include/votca/tools/graphvisitor.h
@@ -91,6 +91,9 @@ class GraphVisitor {
 
   /// Get the set of all the vertices that have been explored
   std::set<int> getExploredVertices();
+
+  /// Has the vertex been explored
+  bool vertexExplored(int vert);
 };
 }
 }

--- a/src/libtools/edge.cc
+++ b/src/libtools/edge.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -17,11 +17,9 @@
  *
  */
 
-#include <iostream>
-#include <list>
-#include <vector>
 #include <algorithm>
-
+#include <iostream>
+#include <vector>
 #include <votca/tools/edge.h>
 
 namespace votca {
@@ -30,7 +28,7 @@ namespace tools {
 using namespace std;
 
 Edge::Edge(int ID1, int ID2) {
-  vertices_ = vector<int>{min({ID1,ID2}), max({ID1,ID2})};
+  vertices_ = vector<int>{min({ID1, ID2}), max({ID1, ID2})};
 }
 
 int Edge::getOtherEndPoint(int ver) const {
@@ -77,5 +75,5 @@ ostream& operator<<(ostream& os, const Edge ed) {
   os << ed.vertices_.front() << " " << ed.vertices_.back() << endl;
   return os;
 }
-}
-}
+}  // namespace tools
+}  // namespace votca

--- a/src/libtools/edgecontainer.cc
+++ b/src/libtools/edgecontainer.cc
@@ -68,9 +68,14 @@ vector<int> EdgeContainer::getVerticesDegree(int degree) const{
   return verts;
 }
 
-bool EdgeContainer::edgeExist(Edge ed) {
-  return adj_list_[ed.getEndPoint1()].count(ed.getEndPoint2()) || 
-    adj_list_[ed.getEndPoint2()].count(ed.getEndPoint1()); 
+bool EdgeContainer::edgeExist(Edge ed){
+  if(adj_list_.count(ed.getEndPoint1())){
+    if(adj_list_[ed.getEndPoint1()].count(ed.getEndPoint2())) return true;
+  }
+  if(adj_list_.count(ed.getEndPoint2())){
+    if(adj_list_[ed.getEndPoint2()].count(ed.getEndPoint1())) return true;
+  }
+  return false;
 }
 
 bool EdgeContainer::vertexExist(int vert) { return adj_list_.count(vert); }

--- a/src/libtools/graph_bf_visitor.cc
+++ b/src/libtools/graph_bf_visitor.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -27,7 +27,7 @@ using namespace std;
 namespace votca {
 namespace tools {
 
-bool Graph_BF_Visitor::queEmpty() { return edge_que_.empty(); }
+bool Graph_BF_Visitor::queEmpty() const { return edge_que_.empty(); }
 
 Edge Graph_BF_Visitor::getEdge_(Graph graph) {
   Edge oldest_edge = edge_que_.at(0).front();

--- a/src/libtools/graph_df_visitor.cc
+++ b/src/libtools/graph_df_visitor.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -27,7 +27,7 @@ using namespace std;
 namespace votca {
 namespace tools {
 
-bool Graph_DF_Visitor::queEmpty() { return edge_stack_.empty(); }
+bool Graph_DF_Visitor::queEmpty() const { return edge_stack_.empty(); }
 
 Edge Graph_DF_Visitor::getEdge_(Graph g) {
   Edge ed = edge_stack_.top();
@@ -38,22 +38,22 @@ Edge Graph_DF_Visitor::getEdge_(Graph g) {
 // Add edges to be explored
 void Graph_DF_Visitor::addEdges_(Graph& g, int vertex) {
   auto eds = g.getNeighEdges(vertex);
-  if(edge_stack_.empty()){
-  // If first edges to be added
-    for(auto ed : eds){
+  if (edge_stack_.empty()) {
+    // If first edges to be added
+    for (auto ed : eds) {
       int neigh_vert = ed.getOtherEndPoint(vertex);
-      if(explored_.count(neigh_vert)==0){
+      if (explored_.count(neigh_vert) == 0) {
         edge_stack_.push(ed);
       }
     }
-  }else{
-    for(auto ed : eds){
+  } else {
+    for (auto ed : eds) {
       int neigh_vert = ed.getOtherEndPoint(vertex);
-      if(explored_.count(neigh_vert)==0){
+      if (explored_.count(neigh_vert) == 0) {
         edge_stack_.push(ed);
       }
     }
   }
 }
-}
-}
+}  // namespace tools
+}  // namespace votca

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -88,8 +88,6 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
   vector<Edge> neigh_edges = g.getNeighEdges(starting_vertex);
   for( auto ed : neigh_edges){
     int neigh_vertex = ed.getOtherEndPoint(starting_vertex);
-
-    cout << "neigh vertex " << neigh_vertex << endl;
     if(gv_breadth_first.vertexExplored(neigh_vertex)){
       branch_edges.insert(ed);
     }

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -87,7 +87,7 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
   }
 
   vector<Edge> neigh_edges = g.getNeighEdges(starting_vertex);
-  for( auto ed : neigh_edges){
+  for( Edge& ed : neigh_edges){
     int neigh_vertex = ed.getOtherEndPoint(starting_vertex);
     if(gv_breadth_first.vertexExplored(neigh_vertex)){
       branch_edges.insert(ed);

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -56,25 +56,28 @@ bool singleNetwork(Graph graph, GraphVisitor& graph_visitor) {
          graph.getIsolatedNodes().size() == 0;
 }
 
-std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
+std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge) {
   // Check if the starting vertex is in the graph
-  if(!g.vertexExist(starting_vertex)){
-    throw invalid_argument("Cannot explore a branch of the graph when the "
+  if (!g.vertexExist(starting_vertex)) {
+    throw invalid_argument(
+        "Cannot explore a branch of the graph when the "
         "exploration is started from a vertex that does not exist within the "
         "graph.");
-  } 
-  if(!g.edgeExist(edge)){
-    throw invalid_argument("Edge does not exist in the graph so exploration of"
+  }
+  if (!g.edgeExist(edge)) {
+    throw invalid_argument(
+        "Edge does not exist in the graph so exploration of"
         " the graph branch cannot continue");
   }
-  if(!edge.contains(starting_vertex)){
-    throw invalid_argument("The edge determining which branch to explore does "
+  if (!edge.contains(starting_vertex)) {
+    throw invalid_argument(
+        "The edge determining which branch to explore does "
         "not contain the starting vertex.");
   }
   Graph_BF_Visitor gv_breadth_first;
   GraphNode gn;
-  pair<int,GraphNode> pr_gn(starting_vertex,gn);
-  gv_breadth_first.exploreNode(pr_gn,g);
+  pair<int, GraphNode> pr_gn(starting_vertex, gn);
+  gv_breadth_first.exploreNode(pr_gn, g);
   gv_breadth_first.setStartingVertex(edge.getOtherEndPoint(starting_vertex));
   gv_breadth_first.initialize(g);
 
@@ -87,9 +90,9 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
   }
 
   vector<Edge> neigh_edges = g.getNeighEdges(starting_vertex);
-  for( Edge& ed : neigh_edges){
+  for (Edge& ed : neigh_edges) {
     int neigh_vertex = ed.getOtherEndPoint(starting_vertex);
-    if(gv_breadth_first.vertexExplored(neigh_vertex)){
+    if (gv_breadth_first.vertexExplored(neigh_vertex)) {
       branch_edges.insert(ed);
     }
   }

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -71,9 +71,31 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
         "not contain the starting vertex.");
   }
   Graph_BF_Visitor gv_breadth_first;
-  gv_breadth_first.setStartingVertex(starting_vertex);
-  GraphNode gn = g.getNode(starting_vertex);
- 
+  GraphNode gn;
+  pair<int,GraphNode> pr_gn(starting_vertex,gn);
+  gv_breadth_first.exploreNode(pr_gn,g);
+  gv_breadth_first.setStartingVertex(edge.getOtherEndPoint(starting_vertex));
+  gv_breadth_first.initialize(g);
+
+  set<Edge> branch_edges;
+  branch_edges.insert(edge);
+  while (!gv_breadth_first.queEmpty()) {
+    Edge ed = gv_breadth_first.nextEdge(g);
+    branch_edges.insert(ed);
+    gv_breadth_first.exec(g, ed);
+  }
+
+  vector<Edge> neigh_edges = g.getNeighEdges(starting_vertex);
+  for( auto ed : neigh_edges){
+    int neigh_vertex = ed.getOtherEndPoint(starting_vertex);
+
+    cout << "neigh vertex " << neigh_vertex << endl;
+    if(gv_breadth_first.vertexExplored(neigh_vertex)){
+      branch_edges.insert(ed);
+    }
+  }
+
+  return branch_edges;
 }
 /**
  * \brief This class is to help keep track of which vertices have and have not

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -57,7 +57,11 @@ bool singleNetwork(Graph g, GraphVisitor& gv) {
 
 std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
   // Check if the starting vertex is in the graph
-  
+  if(!g.vertexExist(starting_vertex)){
+    throw invalid_argument("Cannot explore a branch of the graph when the "
+        "exploration is started from a vertex that does not exist within the "
+        "graph.");
+  } 
   Graph_BF_Visitor gv_breadth_first;
   gv_breadth_first.setStartingVertex(starting_vertex);
 }

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -62,8 +62,18 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
         "exploration is started from a vertex that does not exist within the "
         "graph.");
   } 
+  if(!g.edgeExist(edge)){
+    throw invalid_argument("Edge does not exist in the graph so exploration of"
+        " the graph branch cannot continue");
+  }
+  if(!edge.contains(starting_vertex)){
+    throw invalid_argument("The edge determining which branch to explore does "
+        "not contain the starting vertex.");
+  }
   Graph_BF_Visitor gv_breadth_first;
   gv_breadth_first.setStartingVertex(starting_vertex);
+  GraphNode gn = g.getNode(starting_vertex);
+ 
 }
 /**
  * \brief This class is to help keep track of which vertices have and have not

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -54,6 +54,13 @@ bool singleNetwork(Graph g, GraphVisitor& gv) {
          g.getIsolatedNodes().size() == 0;
 }
 
+std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
+  // Check if the starting vertex is in the graph
+  
+  Graph_BF_Visitor gv_breadth_first;
+  gv_breadth_first.setStartingVertex(*v_it);
+}
+
 vector<shared_ptr<Graph>> decoupleIsolatedSubGraphs(Graph g) {
 
   auto vertices_list = vectorToList_(g.getVertices());

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -49,14 +49,15 @@ vector<Edge> edgeSetToVector_(set<Edge> edges) {
  * Public Functions *
  ********************/
 
-bool singleNetwork(Graph graph, GraphVisitor& graph_visitor) {
+bool singleNetwork(Graph& graph, GraphVisitor& graph_visitor) {
   exploreGraph(graph, graph_visitor);
   return graph_visitor.getExploredVertices().size() ==
              graph.getVertices().size() &&
          graph.getIsolatedNodes().size() == 0;
 }
 
-std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge) {
+std::set<Edge> exploreBranch(Graph& g, const int starting_vertex,
+                             const Edge& edge) {
   // Check if the starting vertex is in the graph
   if (!g.vertexExist(starting_vertex)) {
     throw invalid_argument(

--- a/src/libtools/graphdistvisitor.cc
+++ b/src/libtools/graphdistvisitor.cc
@@ -31,7 +31,7 @@ namespace votca {
 namespace tools {
 
 // Add the distance to the node that has not yet been explored
-void GraphDistVisitor::exploreNode_(pair<int, GraphNode> &p_gn, Graph& g,
+void GraphDistVisitor::exploreNode(pair<int, GraphNode> &p_gn, Graph& g,
                                     Edge ed) {
   // Determine if the node has already been explored
   int vertex = p_gn.first;
@@ -51,7 +51,7 @@ void GraphDistVisitor::exploreNode_(pair<int, GraphNode> &p_gn, Graph& g,
     }
   }
   // Ensure the graph node is set to explored
-  GraphVisitor::exploreNode_(p_gn, g);
+  GraphVisitor::exploreNode(p_gn, g);
 }
 }
 }

--- a/src/libtools/graphvisitor.cc
+++ b/src/libtools/graphvisitor.cc
@@ -62,6 +62,10 @@ void GraphVisitor::initialize(Graph& g){
   addEdges_(g, startingVertex_);
 }
 
+bool GraphVisitor::vertexExplored(int vertex){
+  return explored_.count(vertex)==1;
+}
+
 void GraphVisitor::exec(Graph& g, Edge ed){
   auto unexp_vert = getUnexploredVertex(ed);    
   // If no vertices are return than just ignore it means the same
@@ -73,7 +77,6 @@ void GraphVisitor::exec(Graph& g, Edge ed){
       " did you set the starting node");
   }
   pair<int,GraphNode> pr(unexp_vert.at(0),g.getNode(unexp_vert.at(0)));
- 
   exploreNode(pr,g,ed);
 
 }

--- a/src/libtools/graphvisitor.cc
+++ b/src/libtools/graphvisitor.cc
@@ -39,7 +39,7 @@ void GraphVisitor::addEdges_(Graph& g, int vertex){
   throw runtime_error("addEdges_ method must be defined by your visitor");
 }
 
-void GraphVisitor::exploreNode_(pair<int,GraphNode> &p_gn,Graph& g,Edge ed){
+void GraphVisitor::exploreNode(pair<int,GraphNode> &p_gn,Graph& g,Edge ed){
   explored_.insert(p_gn.first);
 }
 
@@ -58,7 +58,7 @@ void GraphVisitor::initialize(Graph& g){
   auto neigh_eds = g.getNeighEdges(startingVertex_);
   GraphNode gn = g.getNode(startingVertex_);
   pair<int, GraphNode> p_gn(startingVertex_,gn);
-  exploreNode_(p_gn,g);
+  exploreNode(p_gn,g);
   addEdges_(g, startingVertex_);
 }
 
@@ -74,7 +74,7 @@ void GraphVisitor::exec(Graph& g, Edge ed){
   }
   pair<int,GraphNode> pr(unexp_vert.at(0),g.getNode(unexp_vert.at(0)));
  
-  exploreNode_(pr,g,ed);
+  exploreNode(pr,g,ed);
 
 }
 

--- a/src/libtools/graphvisitor.cc
+++ b/src/libtools/graphvisitor.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -31,18 +31,18 @@ namespace tools {
 
 class GraphNode;
 
-bool GraphVisitor::queEmpty() { return true; }
+bool GraphVisitor::queEmpty() const { return true; }
 
 void GraphVisitor::addEdges_(Graph& graph, int vertex) {
   throw runtime_error("addEdges_ method must be defined by your visitor");
 }
 
 void GraphVisitor::exploreNode(pair<int, GraphNode>& vertex_and_node,
-                                Graph& graph, Edge edge) {
+                               Graph& graph, Edge edge) {
   explored_.insert(vertex_and_node.first);
 }
 
-vector<int> GraphVisitor::getUnexploredVertex(Edge edge) {
+vector<int> GraphVisitor::getUnexploredVertex(const Edge edge) const {
   vector<int> unexp_vert;
   if (explored_.count(edge.getEndPoint1()) == 0) {
     unexp_vert.push_back(edge.getEndPoint1());
@@ -53,8 +53,8 @@ vector<int> GraphVisitor::getUnexploredVertex(Edge edge) {
   return unexp_vert;
 }
 
-bool GraphVisitor::vertexExplored(int vertex){
-  return explored_.count(vertex)==1;
+bool GraphVisitor::vertexExplored(const int vertex) const {
+  return explored_.count(vertex) == 1;
 }
 
 void GraphVisitor::initialize(Graph& graph) {
@@ -100,7 +100,7 @@ Edge GraphVisitor::nextEdge(Graph graph) {
   return edge;
 }
 
-set<int> GraphVisitor::getExploredVertices() { return explored_; }
+set<int> GraphVisitor::getExploredVertices() const { return explored_; }
 
 }  // namespace tools
 }  // namespace votca

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(explorebranch_test) {
 
     vector<bool> found_edges(8, false);
     int index = 0;
-    for (Edge & ed : branch_edges) {
+    for (Edge& ed : branch_edges) {
       if (ed == ed3) found_edges.at(index) = true;
       if (ed == ed4) found_edges.at(index) = true;
       if (ed == ed5) found_edges.at(index) = true;

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -159,10 +159,10 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
 
-    auto edges2 = reduced_g.getEdges();
+    vector<Edge> edges2 = reduced_g.getEdges();
     BOOST_CHECK_EQUAL(edges2.size(), 5);
     vector<bool> found_edges(5, false);
-    for (auto edge : edges2) {
+    for (Edge& edge : edges2) {
       if (edge == ed1) found_edges.at(0) = true;
       if (edge == ed2) found_edges.at(1) = true;
       if (edge == ed3) found_edges.at(2) = true;
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
       if (edge == ed5) found_edges.at(4) = true;
     }
 
-    for (auto found : found_edges) {
+    for (bool& found : found_edges) {
       BOOST_CHECK(found);
     }
   }
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
 
     vector<bool> found_edge(4, false);
 
-    for (auto edge : edges3.at(0)) {
+    for (const Edge& edge : edges3.at(0)) {
       if (edge == edges.at(0)) found_edge.at(0) = true;
       if (edge == edges.at(1)) found_edge.at(1) = true;
       if (edge == edges.at(2)) found_edge.at(2) = true;
@@ -316,10 +316,10 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     int edge_count10_12 = 0;
     int edge_count14_14 = 0;
 
-    auto edges2 = reduced_g.getEdges();
+    vector<Edge> edges2 = reduced_g.getEdges();
     BOOST_CHECK_EQUAL(edges2.size(), 7);
 
-    for (auto edge : edges2) {
+    for (Edge& edge : edges2) {
       if (edge == ed0_1) ++edge_count0_1;
       if (edge == ed1_2) ++edge_count1_2;
       if (edge == ed1_6) ++edge_count1_6;
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(explorebranch_test) {
 
     vector<bool> found_edges(8, false);
     int index = 0;
-    for (auto ed : branch_edges) {
+    for (Edge & ed : branch_edges) {
       if (ed == ed3) found_edges.at(index) = true;
       if (ed == ed4) found_edges.at(index) = true;
       if (ed == ed5) found_edges.at(index) = true;
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(explorebranch_test) {
       ++index;
     }
 
-    for (auto found : found_edges) {
+    for (bool& found : found_edges) {
       BOOST_CHECK(found);
     }
   }
@@ -441,7 +441,7 @@ BOOST_AUTO_TEST_CASE(structureid_test) {
 
     Graph g(edges, nodes);
 
-    auto structId = findStructureId<GraphDistVisitor>(g);
+    string structId = findStructureId<GraphDistVisitor>(g);
 
     string answer = "Dist0Dist1Dist1Dist1Dist2Dist2Dist3";
     BOOST_CHECK_EQUAL(structId, answer);

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
       if (edge == ed5) found_edges.at(4) = true;
     }
 
-    for (bool& found : found_edges) {
+    for (const bool& found : found_edges) {
       BOOST_CHECK(found);
     }
   }
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(explorebranch_test) {
 
     vector<bool> found_edges(8, false);
     int index = 0;
-    for (Edge& ed : branch_edges) {
+    for (const Edge& ed : branch_edges) {
       if (ed == ed3) found_edges.at(index) = true;
       if (ed == ed4) found_edges.at(index) = true;
       if (ed == ed5) found_edges.at(index) = true;
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(explorebranch_test) {
       ++index;
     }
 
-    for (bool& found : found_edges) {
+    for (const bool& found : found_edges) {
       BOOST_CHECK(found);
     }
   }

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -293,6 +293,63 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
 
 }
 
+BOOST_AUTO_TEST_CASE(explorebranch_test){
+  {
+    // Create edge
+    //     2 - 10
+    //     |
+    // 0 - 1 - 3 - 9
+    //     |       |
+    //     4 - 5 - 6 -  7 - 8
+
+    Edge ed1(0, 1);
+    Edge ed2(1, 2);
+    Edge ed3(1, 3);
+    Edge ed4(1, 4);
+    Edge ed5(4, 5);
+    Edge ed6(5, 6);
+    Edge ed7(6, 7);
+    Edge ed8(7, 8);
+    Edge ed9(6, 9);
+    Edge ed10(3, 9);
+    Edge ed11(2,10);
+
+    vector<Edge> edges{ ed1, ed2, ed3, ed4, ed5, ed6, ed7, ed8, ed9, ed10, ed11};
+
+    // Create Graph nodes
+    unordered_map<int, GraphNode> nodes;
+    for(int index = 0; index<11;++index){
+      GraphNode gn;
+      nodes[index] = gn;
+    }
+
+    Graph g(edges,nodes);
+
+    int starting_vertex = 1;
+    set<Edge> branch_edges = exploreBranch(g,starting_vertex,ed3);
+
+    BOOST_CHECK_EQUAL(branch_edges.size(),8);
+
+    vector<bool> found_edges(8,false);
+    int index = 0;
+    for (auto ed : branch_edges){
+      if(ed == ed3) found_edges.at(index)=true;
+      if(ed == ed4) found_edges.at(index)=true;
+      if(ed == ed5) found_edges.at(index)=true;
+      if(ed == ed6) found_edges.at(index)=true;
+      if(ed == ed7) found_edges.at(index)=true;
+      if(ed == ed8) found_edges.at(index)=true;
+      if(ed == ed9) found_edges.at(index)=true;
+      if(ed == ed10) found_edges.at(index)=true;
+      ++index;
+    }
+
+    for( auto found : found_edges){
+      BOOST_CHECK(found);
+    }
+  }
+}
+
 BOOST_AUTO_TEST_CASE(structureid_test) {
   {
 

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -376,6 +376,12 @@ BOOST_AUTO_TEST_CASE(explorebranch_test){
     int starting_vertex = 1;
     set<Edge> branch_edges = exploreBranch(g,starting_vertex,ed3);
 
+    // The following edges should be found in the branch
+    //
+    //     1 - 3 - 9
+    //     |       |
+    //     4 - 5 - 6 -  7 - 8
+    //
     BOOST_CHECK_EQUAL(branch_edges.size(),8);
 
     vector<bool> found_edges(8,false);

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -25,11 +25,11 @@
 #include <unordered_map>
 #include <vector>
 #include <votca/tools/graph.h>
-#include <votca/tools/reducedgraph.h>
 #include <votca/tools/graph_bf_visitor.h>
 #include <votca/tools/graphalgorithm.h>
 #include <votca/tools/graphdistvisitor.h>
 #include <votca/tools/graphnode.h>
+#include <votca/tools/reducedgraph.h>
 
 using namespace std;
 using namespace votca::tools;
@@ -38,7 +38,6 @@ using namespace boost;
 using namespace boost::unit_test;
 
 BOOST_AUTO_TEST_SUITE(graphalgorithm_test)
-
 
 BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
   {
@@ -64,7 +63,7 @@ BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
     Graph_BF_Visitor gb_v;
 
     BOOST_CHECK(gb_v.queEmpty());
-    //gb_v.exec(g,ed);
+    // gb_v.exec(g,ed);
     BOOST_CHECK_THROW(gb_v.exec(g, ed), runtime_error);
 
     bool single_n = singleNetwork(g, gb_v);
@@ -157,21 +156,21 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     nodes[5] = gn6;
     nodes[6] = gn7;
 
-    Graph g(edges,nodes);
+    Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
 
     auto edges2 = reduced_g.getEdges();
-    BOOST_CHECK_EQUAL(edges2.size(),5);
-    vector<bool> found_edges(5,false);
-    for(auto edge : edges2 ){
-      if(edge==ed1) found_edges.at(0) = true;
-      if(edge==ed2) found_edges.at(1) = true;
-      if(edge==ed3) found_edges.at(2) = true;
-      if(edge==ed4) found_edges.at(3) = true;
-      if(edge==ed5) found_edges.at(4) = true;
+    BOOST_CHECK_EQUAL(edges2.size(), 5);
+    vector<bool> found_edges(5, false);
+    for (auto edge : edges2) {
+      if (edge == ed1) found_edges.at(0) = true;
+      if (edge == ed2) found_edges.at(1) = true;
+      if (edge == ed3) found_edges.at(2) = true;
+      if (edge == ed4) found_edges.at(3) = true;
+      if (edge == ed5) found_edges.at(4) = true;
     }
 
-    for(auto found : found_edges){
+    for (auto found : found_edges) {
       BOOST_CHECK(found);
     }
   }
@@ -179,49 +178,48 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
   {
     // Test that the reduced graph handles loops correctly
     //
-    // 1 - 2 
+    // 1 - 2
     // |   |
     // 4 - 3
     //
-    // Should reduce this to 
+    // Should reduce this to
     //
     // 1 - 1
     //
-    vector<Edge> edges{ Edge(1,2), Edge(2,3), Edge(3,4),Edge(1,4)};
+    vector<Edge> edges{Edge(1, 2), Edge(2, 3), Edge(3, 4), Edge(1, 4)};
 
     unordered_map<int, GraphNode> nodes;
-    for(int vertex = 1; vertex<=4;++vertex){
+    for (int vertex = 1; vertex <= 4; ++vertex) {
       GraphNode gn;
       nodes[vertex] = gn;
-    } 
-    
-    Graph graph(edges,nodes);
-    ReducedGraph reduced_graph = reduceGraph(graph);
-  
-    vector<Edge> edges2 = reduced_graph.getEdges();
-    BOOST_CHECK_EQUAL(edges2.size(),1);
-
-    Edge ed_check(1,1);
-    BOOST_CHECK_EQUAL(edges2.at(0),ed_check);
-
-    vector<vector<Edge>> edges3 = reduced_graph.expandEdge(ed_check);
-    BOOST_CHECK_EQUAL(edges3.size(),1);
-    BOOST_CHECK_EQUAL(edges3.at(0).size(),4);
-
-    vector<bool> found_edge(4,false);
-   
-    for(auto edge : edges3.at(0)){
-      if(edge==edges.at(0)) found_edge.at(0) = true;
-      if(edge==edges.at(1)) found_edge.at(1) = true;
-      if(edge==edges.at(2)) found_edge.at(2) = true;
-      if(edge==edges.at(3)) found_edge.at(3) = true;
     }
 
-    for(bool found : found_edge){
+    Graph graph(edges, nodes);
+    ReducedGraph reduced_graph = reduceGraph(graph);
+
+    vector<Edge> edges2 = reduced_graph.getEdges();
+    BOOST_CHECK_EQUAL(edges2.size(), 1);
+
+    Edge ed_check(1, 1);
+    BOOST_CHECK_EQUAL(edges2.at(0), ed_check);
+
+    vector<vector<Edge>> edges3 = reduced_graph.expandEdge(ed_check);
+    BOOST_CHECK_EQUAL(edges3.size(), 1);
+    BOOST_CHECK_EQUAL(edges3.at(0).size(), 4);
+
+    vector<bool> found_edge(4, false);
+
+    for (auto edge : edges3.at(0)) {
+      if (edge == edges.at(0)) found_edge.at(0) = true;
+      if (edge == edges.at(1)) found_edge.at(1) = true;
+      if (edge == edges.at(2)) found_edge.at(2) = true;
+      if (edge == edges.at(3)) found_edge.at(3) = true;
+    }
+
+    for (bool found : found_edge) {
       BOOST_CHECK(found);
     }
   }
-
 
   {
     // Create edge
@@ -243,36 +241,36 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     Edge ed10(3, 9);
 
     //
-    // 10 - 11 - 12 
+    // 10 - 11 - 12
     //
     // 13
     //
-    // 14 - 15 
+    // 14 - 15
     // |    |
     // 16 - 17
     //
     Edge ed11(10, 11);
     Edge ed12(11, 12);
 
-    Edge ed13(14,15);
-    Edge ed14(15,17);
-    Edge ed15(16,17);
-    Edge ed16(14,16);
+    Edge ed13(14, 15);
+    Edge ed14(15, 17);
+    Edge ed15(16, 17);
+    Edge ed16(14, 16);
 
-    vector<Edge> edges{ ed1, ed2, ed3, ed4, ed5, ed6, ed7, ed8, ed9, ed10,
-      ed11, ed12, ed13, ed14, ed15, ed16};
+    vector<Edge> edges{ed1, ed2,  ed3,  ed4,  ed5,  ed6,  ed7,  ed8,
+                       ed9, ed10, ed11, ed12, ed13, ed14, ed15, ed16};
 
     // Create Graph nodes
     unordered_map<int, GraphNode> nodes;
-    for(int index = 0; index<18;++index){
+    for (int index = 0; index < 18; ++index) {
       GraphNode gn;
       nodes[index] = gn;
     }
 
-    Graph g(edges,nodes);
+    Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
 
-    // Full Graph 
+    // Full Graph
     //
     //     2
     //     |
@@ -280,11 +278,11 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     //     |       |
     //     4 - 5 - 6 -  7 - 8
     //
-    // 10 - 11 - 12 
+    // 10 - 11 - 12
     //
     // 13
     //
-    // 14 - 15 
+    // 14 - 15
     // |    |
     // 16 - 17
     //
@@ -292,56 +290,54 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     //
     //     2
     //     |
-    // 0 - 1 - 
+    // 0 - 1 -
     //     |   |
     //       - 6 - 8
     //
-    // 10 - 12 
+    // 10 - 12
     //
     // 13
     //
-    // 14 -  
+    // 14 -
     // |  |
-    //  - 
+    //  -
     //
-    Edge ed0_1(0,1);
-    Edge ed1_2(1,2);
-    Edge ed1_6(1,6);
-    Edge ed6_8(6,8);
-    Edge ed10_12(10,12);
-    Edge ed14_14(14,14);
+    Edge ed0_1(0, 1);
+    Edge ed1_2(1, 2);
+    Edge ed1_6(1, 6);
+    Edge ed6_8(6, 8);
+    Edge ed10_12(10, 12);
+    Edge ed14_14(14, 14);
 
-    int edge_count0_1 = 0; 
-    int edge_count1_2 = 0; 
-    int edge_count1_6 = 0; 
-    int edge_count6_8 = 0; 
-    int edge_count10_12 = 0; 
-    int edge_count14_14 = 0; 
+    int edge_count0_1 = 0;
+    int edge_count1_2 = 0;
+    int edge_count1_6 = 0;
+    int edge_count6_8 = 0;
+    int edge_count10_12 = 0;
+    int edge_count14_14 = 0;
 
     auto edges2 = reduced_g.getEdges();
-    BOOST_CHECK_EQUAL(edges2.size(),7);
+    BOOST_CHECK_EQUAL(edges2.size(), 7);
 
-    for(auto edge : edges2 ){
-      if(edge==ed0_1) ++edge_count0_1;
-      if(edge==ed1_2) ++edge_count1_2;
-      if(edge==ed1_6) ++edge_count1_6;
-      if(edge==ed6_8) ++edge_count6_8;
-      if(edge==ed10_12) ++edge_count10_12;
-      if(edge==ed14_14) ++edge_count14_14;
-    } 
+    for (auto edge : edges2) {
+      if (edge == ed0_1) ++edge_count0_1;
+      if (edge == ed1_2) ++edge_count1_2;
+      if (edge == ed1_6) ++edge_count1_6;
+      if (edge == ed6_8) ++edge_count6_8;
+      if (edge == ed10_12) ++edge_count10_12;
+      if (edge == ed14_14) ++edge_count14_14;
+    }
 
-    BOOST_CHECK_EQUAL(edge_count0_1,1);
-    BOOST_CHECK_EQUAL(edge_count1_2,1);
-    BOOST_CHECK_EQUAL(edge_count1_6,2);
-    BOOST_CHECK_EQUAL(edge_count6_8,1);
-    BOOST_CHECK_EQUAL(edge_count10_12,1);
-    BOOST_CHECK_EQUAL(edge_count14_14,1);
-
+    BOOST_CHECK_EQUAL(edge_count0_1, 1);
+    BOOST_CHECK_EQUAL(edge_count1_2, 1);
+    BOOST_CHECK_EQUAL(edge_count1_6, 2);
+    BOOST_CHECK_EQUAL(edge_count6_8, 1);
+    BOOST_CHECK_EQUAL(edge_count10_12, 1);
+    BOOST_CHECK_EQUAL(edge_count14_14, 1);
   }
-
 }
 
-BOOST_AUTO_TEST_CASE(explorebranch_test){
+BOOST_AUTO_TEST_CASE(explorebranch_test) {
   {
     // Create edge
     //     2 - 10
@@ -360,21 +356,21 @@ BOOST_AUTO_TEST_CASE(explorebranch_test){
     Edge ed8(7, 8);
     Edge ed9(6, 9);
     Edge ed10(3, 9);
-    Edge ed11(2,10);
+    Edge ed11(2, 10);
 
-    vector<Edge> edges{ ed1, ed2, ed3, ed4, ed5, ed6, ed7, ed8, ed9, ed10, ed11};
+    vector<Edge> edges{ed1, ed2, ed3, ed4, ed5, ed6, ed7, ed8, ed9, ed10, ed11};
 
     // Create Graph nodes
     unordered_map<int, GraphNode> nodes;
-    for(int index = 0; index<11;++index){
+    for (int index = 0; index < 11; ++index) {
       GraphNode gn;
       nodes[index] = gn;
     }
 
-    Graph g(edges,nodes);
+    Graph g(edges, nodes);
 
     int starting_vertex = 1;
-    set<Edge> branch_edges = exploreBranch(g,starting_vertex,ed3);
+    set<Edge> branch_edges = exploreBranch(g, starting_vertex, ed3);
 
     // The following edges should be found in the branch
     //
@@ -382,23 +378,23 @@ BOOST_AUTO_TEST_CASE(explorebranch_test){
     //     |       |
     //     4 - 5 - 6 -  7 - 8
     //
-    BOOST_CHECK_EQUAL(branch_edges.size(),8);
+    BOOST_CHECK_EQUAL(branch_edges.size(), 8);
 
-    vector<bool> found_edges(8,false);
+    vector<bool> found_edges(8, false);
     int index = 0;
-    for (auto ed : branch_edges){
-      if(ed == ed3) found_edges.at(index)=true;
-      if(ed == ed4) found_edges.at(index)=true;
-      if(ed == ed5) found_edges.at(index)=true;
-      if(ed == ed6) found_edges.at(index)=true;
-      if(ed == ed7) found_edges.at(index)=true;
-      if(ed == ed8) found_edges.at(index)=true;
-      if(ed == ed9) found_edges.at(index)=true;
-      if(ed == ed10) found_edges.at(index)=true;
+    for (auto ed : branch_edges) {
+      if (ed == ed3) found_edges.at(index) = true;
+      if (ed == ed4) found_edges.at(index) = true;
+      if (ed == ed5) found_edges.at(index) = true;
+      if (ed == ed6) found_edges.at(index) = true;
+      if (ed == ed7) found_edges.at(index) = true;
+      if (ed == ed8) found_edges.at(index) = true;
+      if (ed == ed9) found_edges.at(index) = true;
+      if (ed == ed10) found_edges.at(index) = true;
       ++index;
     }
 
-    for( auto found : found_edges){
+    for (auto found : found_edges) {
       BOOST_CHECK(found);
     }
   }


### PR DESCRIPTION
This branch includes an algorithm that will explore a chosen branch within a graph. If you were to choose a vertex within the graph and pick one of the edges connected to vertex and explore all the way down the tree from that point on you would explore the branch. In the case that the exploration returns back to the vertex it will not continue past the starting point. 

E.g. If I have a graph
<pre>
1 - 2 - 3 - 4 
|   |
5 - 6
</pre>

And my starting vertex is two and I set the branch to explore by specifying edge 1 - 2. I would end up with a branch that looked like this:

<pre>
1 - 2 
|   |
5 - 6
</pre>

The purpose of doing this is it provides the basis for defining functionality to resolve this structural components of molecules. 

Should only be merged after: https://github.com/votca/tools/pull/94