### PR TITLE
Add expand graph method to reduced graph

### DIFF
--- a/include/votca/tools/edgecontainer.h
+++ b/include/votca/tools/edgecontainer.h
@@ -52,12 +52,16 @@ class EdgeContainer {
   std::vector<int> getVerticesDegree(int degree) const;
   /// Determine the degree of the vertex/number of edges attached
   int getDegree(const int vertex) const;
+
+  bool vertexExistWithDegree(int degree) const;
+
   /// Check if the edge exists returns true or false
   bool edgeExist(const Edge& edge) const;
   /// Check if the vertex exists returns true or false
   bool vertexExist(int vertex) const;
   /// Add an edge to the container
   void addEdge(Edge edge);
+  void addVertex(int vertex);
   /// Get all the edges in vector form
   std::vector<Edge> getEdges() const;
   /// Get all the vertices in vector form

--- a/include/votca/tools/edgecontainer.h
+++ b/include/votca/tools/edgecontainer.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -53,7 +53,7 @@ class EdgeContainer {
   /// Determine the degree of the vertex/number of edges attached
   int getDegree(const int vertex) const;
   /// Check if the edge exists returns true or false
-  bool edgeExist(Edge edge) const;
+  bool edgeExist(const Edge& edge) const;
   /// Check if the vertex exists returns true or false
   bool vertexExist(int vertex) const;
   /// Add an edge to the container
@@ -61,11 +61,11 @@ class EdgeContainer {
   /// Get all the edges in vector form
   std::vector<Edge> getEdges() const;
   /// Get all the vertices in vector form
-  std::vector<int> getVertices();
+  std::vector<int> getVertices() const;
   /// Get the vertices neighboring vert
-  std::vector<int> getNeighVertices(int vertex);
+  std::vector<int> getNeighVertices(int vertex) const;
   /// Get the edges neighboring vert
-  std::vector<Edge> getNeighEdges(int vertex);
+  std::vector<Edge> getNeighEdges(int vertex) const;
   /// Print output of object
   friend std::ostream& operator<<(std::ostream& os,
                                   const EdgeContainer edge_container);

--- a/include/votca/tools/edgecontainer.h
+++ b/include/votca/tools/edgecontainer.h
@@ -52,7 +52,7 @@ class EdgeContainer {
   std::vector<int> getVerticesDegree(int degree) const;
   /// Determine the degree of the vertex/number of edges attached
   int getDegree(const int vertex) const;
-
+  /// Determine if a vertex with the specified degree exists
   bool vertexExistWithDegree(int degree) const;
 
   /// Check if the edge exists returns true or false
@@ -61,6 +61,7 @@ class EdgeContainer {
   bool vertexExist(int vertex) const;
   /// Add an edge to the container
   void addEdge(Edge edge);
+  /// Add a lone vertex
   void addVertex(int vertex);
   /// Get all the edges in vector form
   std::vector<Edge> getEdges() const;

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -76,7 +76,7 @@ class Graph {
 
   /// Find all the vertices that are isolated (not connected to any other
   /// vertex) and return them in a vector with their corresponding graph node.
-  std::vector<std::pair<int, GraphNode>> getIsolatedNodes(void);
+  std::vector<std::pair<int, GraphNode>> getIsolatedNodes(void) const;
 
   /// Functions determines which vertices do not have a graph node associated
   /// with them and return their ids in a vector.
@@ -84,7 +84,7 @@ class Graph {
 
   /// Returns a vector of the vertices and their graph nodes that are directly
   /// connected to the vertex 'vert'
-  std::vector<std::pair<int, GraphNode>> getNeighNodes(int vertex);
+  std::vector<std::pair<int, GraphNode>> getNeighNodes(int vertex) const;
 
   /// set the Node associated with vertex 'vert'
   void setNode(int vertex, GraphNode& graph_node);
@@ -97,11 +97,11 @@ class Graph {
   GraphNode getNode(const int vertex) const;
 
   /// Return all the vertices and their graph nodes that are within the graph
-  virtual std::vector<std::pair<int, GraphNode>> getNodes(void);
+  virtual std::vector<std::pair<int, GraphNode>> getNodes(void) const;
 
   /// Returns all the vertices of the graph connected to vertex `vert` through
   /// an edge.
-  std::vector<int> getNeighVertices(int vertex) {
+  std::vector<int> getNeighVertices(int vertex) const {
     return edge_container_.getNeighVertices(vertex);
   }
 
@@ -112,12 +112,12 @@ class Graph {
   std::vector<Edge> getEdges() { return edge_container_.getEdges(); }
 
   /// Returns all the edges in the graph connected to vertex `vertex`
-  std::vector<Edge> getNeighEdges(int vertex) {
+  std::vector<Edge> getNeighEdges(int vertex) const {
     return edge_container_.getNeighEdges(vertex);
   }
 
   /// Returns all the vertices in the graph
-  std::vector<int> getVertices() { return edge_container_.getVertices(); }
+  std::vector<int> getVertices() const { return edge_container_.getVertices(); }
 
   /**
    * \brief Finds the max degree of a vertex in the graph.
@@ -135,10 +135,12 @@ class Graph {
   virtual std::vector<int> getVerticesDegree(int degree) const;
 
   /// Determines if a vertex exists within the graph
-  bool vertexExist(int vertex);
+  bool vertexExist(int vertex) const;
 
   /// Determines if an edge is stored in the graph
-  bool edgeExist(Edge edge) { return edge_container_.edgeExist(edge); }
+  bool edgeExist(const Edge& edge) const {
+    return edge_container_.edgeExist(edge);
+  }
 
   /// Copies nodes from one graph to another. This should only be used in cases
   /// where the graph does not contain nodes before the copy.

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -129,7 +129,7 @@ class Graph {
   int getMaxDegree() const { return edge_container_.getMaxDegree(); }
 
   /// Calcualtes the degree, or number of edges connected to vertex `vertex`
-  int getDegree(int vertex) const; 
+  int getDegree(int vertex) const;
 
   /// Returns all the vertices with degree specified by `degree`
   virtual std::vector<int> getVerticesDegree(int degree) const;
@@ -140,7 +140,7 @@ class Graph {
   /// Determines if an edge is stored in the graph
   bool edgeExist(Edge edge) { return edge_container_.edgeExist(edge); }
 
-  void copyNodes(Graph & graph);
+  void copyNodes(Graph& graph);
 
   friend std::ostream& operator<<(std::ostream& os, const Graph graph);
 };

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -110,7 +110,7 @@ class Graph {
   }
 
   /// Returns all the vertices in the graph
-  virtual std::vector<int> getVertices() const;
+  std::vector<int> getVertices() const;
 
   /**
    * \brief Finds the max degree of a vertex in the graph.

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -129,18 +129,18 @@ class Graph {
   int getMaxDegree() const { return edge_container_.getMaxDegree(); }
 
   /// Calcualtes the degree, or number of edges connected to vertex `vertex`
-  int getDegree(int vertex) const { return edge_container_.getDegree(vertex); }
+  int getDegree(int vertex) const; 
 
   /// Returns all the vertices with degree specified by `degree`
-  std::vector<int> getVerticesDegree(int degree) const {
-    return edge_container_.getVerticesDegree(degree);
-  }
+  virtual std::vector<int> getVerticesDegree(int degree) const;
 
   /// Determines if a vertex exists within the graph
-  bool vertexExist(int vertex) { return edge_container_.vertexExist(vertex); }
+  bool vertexExist(int vertex);
 
   /// Determines if an edge is stored in the graph
   bool edgeExist(Edge edge) { return edge_container_.edgeExist(edge); }
+
+  void copyNodes(Graph & graph);
 
   friend std::ostream& operator<<(std::ostream& os, const Graph graph);
 };

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -141,7 +141,7 @@ class Graph {
   bool edgeExist(Edge edge) { return edge_container_.edgeExist(edge); }
 
   /// Copies nodes from one graph to another. This should only be used in cases
-  /// where the graph does not contain nodes before the copy. 
+  /// where the graph does not contain nodes before the copy.
   void copyNodes(Graph& graph);
 
   friend std::ostream& operator<<(std::ostream& os, const Graph graph);

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -58,7 +58,7 @@ class Graph {
 
  public:
   Graph() : id_(""){};
-  virtual ~Graph() {};
+  virtual ~Graph(){};
   /// Constructor
   /// @param edgs - vector of edges where each edge is composed of two
   /// ints (vertex ids) describing a link between the vertices

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -140,6 +140,8 @@ class Graph {
   /// Determines if an edge is stored in the graph
   bool edgeExist(Edge edge) { return edge_container_.edgeExist(edge); }
 
+  /// Copies nodes from one graph to another. This should only be used in cases
+  /// where the graph does not contain nodes before the copy. 
   void copyNodes(Graph& graph);
 
   friend std::ostream& operator<<(std::ostream& os, const Graph graph);

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -64,10 +64,7 @@ class Graph {
   /// ints (vertex ids) describing a link between the vertices
   /// @param nodes - unordered_map where the key is the vertex id and the
   /// target is the graph node
-  Graph(std::vector<Edge> edgs, std::unordered_map<int, GraphNode> nodes)
-      : edge_container_(edgs), nodes_(nodes) {
-    calcId_();
-  }
+  Graph(std::vector<Edge> edgs, std::unordered_map<int, GraphNode> nodes);
 
   /// Equivalence and non equivalence operators work by determine if the
   /// contents of each graph node in each of the graphs are the same.
@@ -117,7 +114,7 @@ class Graph {
   }
 
   /// Returns all the vertices in the graph
-  std::vector<int> getVertices() const { return edge_container_.getVertices(); }
+  virtual std::vector<int> getVertices() const;
 
   /**
    * \brief Finds the max degree of a vertex in the graph.

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -75,10 +75,6 @@ class Graph {
   /// vertex) and return them in a vector with their corresponding graph node.
   std::vector<std::pair<int, GraphNode>> getIsolatedNodes(void) const;
 
-  /// Functions determines which vertices do not have a graph node associated
-  /// with them and return their ids in a vector.
-  std::vector<int> getVerticesMissingNodes(void);
-
   /// Returns a vector of the vertices and their graph nodes that are directly
   /// connected to the vertex 'vert'
   std::vector<std::pair<int, GraphNode>> getNeighNodes(int vertex) const;
@@ -139,6 +135,8 @@ class Graph {
     return edge_container_.edgeExist(edge);
   }
 
+  /// Remove contents of all nodes
+  void clearNodes();
   /// Copies nodes from one graph to another. This should only be used in cases
   /// where the graph does not contain nodes before the copy.
   void copyNodes(Graph& graph);

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -87,14 +87,14 @@ class Graph {
   std::vector<std::pair<int, GraphNode>> getNeighNodes(int vertex);
 
   /// set the Node associated with vertex 'vert'
-  void setNode(int vertex, GraphNode graph_node);
-  void setNode(std::pair<int, GraphNode> id_and_node);
+  void setNode(int vertex, GraphNode& graph_node);
+  void setNode(std::pair<int, GraphNode>& id_and_node);
 
   /// Gets all vertices with degree of 3 or greater
   std::vector<int> getJunctions() const;
 
   /// Return a copy of the graph node at vertex 'vert'
-  GraphNode getNode(int vertex);
+  GraphNode getNode(const int vertex) const;
 
   /// Return all the vertices and their graph nodes that are within the graph
   virtual std::vector<std::pair<int, GraphNode>> getNodes(void);

--- a/include/votca/tools/graph.h
+++ b/include/votca/tools/graph.h
@@ -106,7 +106,7 @@ class Graph {
   std::string getId() const { return id_; }
 
   /// Returns all the edges in the graph
-  std::vector<Edge> getEdges() { return edge_container_.getEdges(); }
+  virtual std::vector<Edge> getEdges() { return edge_container_.getEdges(); }
 
   /// Returns all the edges in the graph connected to vertex `vertex`
   std::vector<Edge> getNeighEdges(int vertex) const {
@@ -135,7 +135,7 @@ class Graph {
   bool vertexExist(int vertex) const;
 
   /// Determines if an edge is stored in the graph
-  bool edgeExist(const Edge& edge) const {
+  virtual bool edgeExist(const Edge& edge) const {
     return edge_container_.edgeExist(edge);
   }
 

--- a/include/votca/tools/graph_bf_visitor.h
+++ b/include/votca/tools/graph_bf_visitor.h
@@ -44,8 +44,8 @@ class Graph_BF_Visitor : public GraphVisitor {
 
   /// The core of the breadth first visitor is in how the edges are added
   /// to the queue in this function
-  void addEdges_(Graph& graph, int vertex);
-  Edge getEdge_(Graph graph);
+  void addEdges_(const Graph& graph, int vertex);
+  Edge getEdge_(const Graph& graph);
 
  public:
   Graph_BF_Visitor(){};

--- a/include/votca/tools/graph_df_visitor.h
+++ b/include/votca/tools/graph_df_visitor.h
@@ -43,8 +43,8 @@ class Graph_DF_Visitor : public GraphVisitor {
 
   /// The core of the breadth first visitor is in how the edges are added
   /// to the queue in this function
-  void addEdges_(Graph& g, int vertex);
-  Edge getEdge_(Graph g);
+  void addEdges_(const Graph& g, int vertex);
+  Edge getEdge_(const Graph& g);
 
  public:
   Graph_DF_Visitor(){};

--- a/include/votca/tools/graph_df_visitor.h
+++ b/include/votca/tools/graph_df_visitor.h
@@ -20,7 +20,7 @@
 #ifndef __VOTCA_TOOLS_GRAPH_DF_VISITOR_H
 #define __VOTCA_TOOLS_GRAPH_DF_VISITOR_H
 
-#include <stack>
+#include <list>
 #include <votca/tools/graphvisitor.h>
 
 /**
@@ -39,7 +39,7 @@ class GraphNode;
 
 class Graph_DF_Visitor : public GraphVisitor {
  private:
-  std::stack<Edge> edge_stack_;
+  std::list<Edge> edge_list_;
 
   /// The core of the breadth first visitor is in how the edges are added
   /// to the queue in this function

--- a/include/votca/tools/graph_df_visitor.h
+++ b/include/votca/tools/graph_df_visitor.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -50,6 +50,6 @@ class Graph_DF_Visitor : public GraphVisitor {
   Graph_DF_Visitor(){};
   bool queEmpty();
 };
-}
-}
+}  // namespace tools
+}  // namespace votca
 #endif  // __VOTCA_TOOLS_GRAPH_DF_VISITOR_H

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -130,7 +130,7 @@ ReducedGraph reduceGraph(Graph graph);
  * @return - vector containing shared pointers to all the sub graphs if there
  *           are no subgraphs than the input graph is returned.
  */
-std::vector<Graph> decoupleIsolatedSubGraphs(Graph graph);
+std::vector<Graph> decoupleIsolatedSubGraphs(Graph& graph);
 
 /**
  * \brief Explore a graph with a graph visitor.

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -135,16 +135,12 @@ std::string findStructureId(Graph& graph) {
   // Get the vertices with this degree
   std::vector<int> vertices = graph.getVerticesDegree(maxD);
 
-  std::cout << "Number of vertices " << vertices.size() << " with max degree "
-            << maxD << std::endl;
   // Get the nodes and determine which node has the greatest stringID
   // When compared using compare function
   std::string str_id = "";
   std::vector<int> graph_node_ids;
   for (const int& vertex : vertices) {
     auto graph_node = graph.getNode(vertex);
-    std::cout << "graph_node string id " << graph_node.getStringId()
-              << std::endl;
     int comp_int = str_id.compare(graph_node.getStringId());
     if (comp_int > 0) {
       str_id = graph_node.getStringId();
@@ -160,7 +156,6 @@ std::string findStructureId(Graph& graph) {
   if (str_id.compare("") == 0) {
     graph_node_ids = vertices;
   }
-  std::cout << "Size of graph node ids " << graph_node_ids.size() << std::endl;
   // If two or more graph nodes are found to be equal then
   // they must all be explored
   std::string chosenId = "";
@@ -168,7 +163,6 @@ std::string findStructureId(Graph& graph) {
 
   for (const int& vertex : graph_node_ids) {
     GV graph_visitor;
-    std::cout << "Setting starting node to " << vertex << std::endl;
     graph_visitor.setStartingVertex(vertex);
     Graph graph_temp = graph;
     exploreGraph(graph_temp, graph_visitor);

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -179,7 +179,6 @@ std::string findStructureId(Graph& graph) {
       graph_node_ids.push_back(vertex);
     }
   }
-
   // If the str_id is empty it means the nodes are empty and we will
   // simply have to rely on the degree to choose the vertices to explore from
   if (str_id.compare("") == 0) {

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -135,14 +135,16 @@ std::string findStructureId(Graph& graph) {
   // Get the vertices with this degree
   std::vector<int> vertices = graph.getVerticesDegree(maxD);
 
-  std::cout << "Number of vertices " << vertices.size() << " with max degree " << maxD << std::endl;
+  std::cout << "Number of vertices " << vertices.size() << " with max degree "
+            << maxD << std::endl;
   // Get the nodes and determine which node has the greatest stringID
   // When compared using compare function
   std::string str_id = "";
   std::vector<int> graph_node_ids;
   for (const int& vertex : vertices) {
     auto graph_node = graph.getNode(vertex);
-    std::cout << "graph_node string id " << graph_node.getStringId() << std::endl;
+    std::cout << "graph_node string id " << graph_node.getStringId()
+              << std::endl;
     int comp_int = str_id.compare(graph_node.getStringId());
     if (comp_int > 0) {
       str_id = graph_node.getStringId();

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -101,7 +101,7 @@ ReducedGraph reduceGraph(Graph graph);
  * @return - vector containing shared pointers to all the sub graphs if there
  *           are no subgraphs than the input graph is returned.
  */
-std::vector<std::shared_ptr<Graph>> decoupleIsolatedSubGraphs(Graph graph);
+std::vector<Graph> decoupleIsolatedSubGraphs(Graph graph);
 
 /**
  * \brief Explore a graph with a graph visitor.

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -51,7 +51,7 @@ class GraphVisitor;
  * @param[in,out] - Graph visitor reference instance used to explore the graph
  * @return - Boolean value (true - if single network)
  */
-bool singleNetwork(Graph graph, GraphVisitor& graph_visitor);
+bool singleNetwork(Graph& graph, GraphVisitor& graph_visitor);
 
 /**
  * \brief Explore one of the branches if exploration is initiated at vertex
@@ -169,7 +169,7 @@ std::string findStructureId(Graph& graph) {
   std::string str_id = "";
   std::vector<int> graph_node_ids;
   for (const int& vertex : vertices) {
-    auto graph_node = graph.getNode(vertex);
+    GraphNode graph_node = graph.getNode(vertex);
     int comp_int = str_id.compare(graph_node.getStringId());
     if (comp_int > 0) {
       str_id = graph_node.getStringId();

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -135,12 +135,14 @@ std::string findStructureId(Graph& graph) {
   // Get the vertices with this degree
   std::vector<int> vertices = graph.getVerticesDegree(maxD);
 
+  std::cout << "Number of vertices " << vertices.size() << " with max degree " << maxD << std::endl;
   // Get the nodes and determine which node has the greatest stringID
   // When compared using compare function
   std::string str_id = "";
   std::vector<int> graph_node_ids;
   for (const int& vertex : vertices) {
     auto graph_node = graph.getNode(vertex);
+    std::cout << "graph_node string id " << graph_node.getStringId() << std::endl;
     int comp_int = str_id.compare(graph_node.getStringId());
     if (comp_int > 0) {
       str_id = graph_node.getStringId();
@@ -156,7 +158,7 @@ std::string findStructureId(Graph& graph) {
   if (str_id.compare("") == 0) {
     graph_node_ids = vertices;
   }
-
+  std::cout << "Size of graph node ids " << graph_node_ids.size() << std::endl;
   // If two or more graph nodes are found to be equal then
   // they must all be explored
   std::string chosenId = "";
@@ -164,6 +166,7 @@ std::string findStructureId(Graph& graph) {
 
   for (const int& vertex : graph_node_ids) {
     GV graph_visitor;
+    std::cout << "Setting starting node to " << vertex << std::endl;
     graph_visitor.setStartingVertex(vertex);
     Graph graph_temp = graph;
     exploreGraph(graph_temp, graph_visitor);

--- a/include/votca/tools/graphalgorithm.h
+++ b/include/votca/tools/graphalgorithm.h
@@ -51,7 +51,7 @@ class GraphVisitor;
  * @param[in,out] - Graph visitor reference instance used to explore the graph
  * @return - Boolean value (true - if single network)
  */
-bool singleNetwork(Graph& graph, GraphVisitor& graph_visitor);
+bool singleNetwork(Graph graph, GraphVisitor& graph_visitor);
 
 /**
  * \brief Explore one of the branches if exploration is initiated at vertex
@@ -89,8 +89,7 @@ bool singleNetwork(Graph& graph, GraphVisitor& graph_visitor);
  * @param[in] - the edge indicating which branch is to be explored
  * @return - set of edges in the branch that were explored
  **/
-std::set<Edge> exploreBranch(Graph& g, const int starting_vertex,
-                             const Edge& edge);
+std::set<Edge> exploreBranch(Graph g, int starting_vertex, const Edge& edge);
 
 /**
  * \brief Will take a graph and reduce it, by removing all vertices with degree
@@ -131,7 +130,7 @@ ReducedGraph reduceGraph(Graph graph);
  * @return - vector containing shared pointers to all the sub graphs if there
  *           are no subgraphs than the input graph is returned.
  */
-std::vector<Graph> decoupleIsolatedSubGraphs(Graph& graph);
+std::vector<Graph> decoupleIsolatedSubGraphs(Graph graph);
 
 /**
  * \brief Explore a graph with a graph visitor.

--- a/include/votca/tools/graphvisitor.h
+++ b/include/votca/tools/graphvisitor.h
@@ -56,8 +56,8 @@ class GraphVisitor {
   int startingVertex_ = 0;
 
   /// What is done to an individual graph node as it is explored
-  virtual void addEdges_(Graph& graph, int vertex);
-  virtual Edge getEdge_(Graph graph);
+  virtual void addEdges_(const Graph& graph, int vertex);
+  virtual Edge getEdge_(const Graph& graph);
   /// Edge(0,0) is a dummy value
  public:
   virtual void exploreNode(std::pair<int, GraphNode>& vertex_and_node,

--- a/include/votca/tools/graphvisitor.h
+++ b/include/votca/tools/graphvisitor.h
@@ -56,8 +56,8 @@ class GraphVisitor {
   int startingVertex_ = 0;
 
   /// What is done to an individual graph node as it is explored
-  virtual void addEdges_(const Graph& graph, int vertex);
-  virtual Edge getEdge_(const Graph& graph);
+  virtual void addEdges_(const Graph& graph, int vertex) = 0;
+  virtual Edge getEdge_(const Graph& graph) = 0;
   /// Edge(0,0) is a dummy value
  public:
   virtual void exploreNode(std::pair<int, GraphNode>& vertex_and_node,

--- a/include/votca/tools/reducededge.h
+++ b/include/votca/tools/reducededge.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -52,6 +52,7 @@ class ReducedEdge : public Edge {
   /// Creates an edge the smallest integer value will be placed in the id1
   /// spot and the larger in the id2 spot
   ReducedEdge(std::vector<int> chain);
+
   ReducedEdge(int vertex1, int vertex2)
       : ReducedEdge(std::vector<int>{vertex1, vertex2}){};
 

--- a/include/votca/tools/reducedgraph.h
+++ b/include/votca/tools/reducedgraph.h
@@ -108,11 +108,8 @@ class ReducedGraph : public Graph {
    **/
   std::vector<std::vector<Edge>> expandEdge(const Edge& edge) const;
 
-  /// Get edges
-  std::vector<Edge> getEdges();
-
   /// This method will return a copy of the full graph
-  Graph expandGraph();
+  Graph expandGraph() const;
 
   /**
    * \brief Gets the junctions in the graph.
@@ -136,8 +133,6 @@ class ReducedGraph : public Graph {
   // std::vector<int> getJunctions() const;
 
   std::vector<std::pair<int, GraphNode>> getNodes(void) const;
-
-  std::vector<int> getVertices() const;
 
   std::vector<int> getVerticesDegree(int degree) const;
 

--- a/include/votca/tools/reducedgraph.h
+++ b/include/votca/tools/reducedgraph.h
@@ -105,7 +105,12 @@ class ReducedGraph : public Graph {
    **/
   std::vector<std::vector<Edge>> expandEdge(Edge edge);
 
+  /// This method will return a copy of the full graph
+  Graph expandGraph();
+
   std::vector<std::pair<int, GraphNode>> getNodes(void);
+
+  std::vector<int> getVerticesDegree(int degree) const;
 
   friend std::ostream& operator<<(std::ostream& os, const ReducedGraph graph);
 };

--- a/include/votca/tools/reducedgraph.h
+++ b/include/votca/tools/reducedgraph.h
@@ -74,6 +74,9 @@ class ReducedGraph : public Graph {
   void init_(std::vector<ReducedEdge> reduced_edges,
              std::unordered_map<int, GraphNode> nodes);
 
+  // Junctions must be stored internally
+  std::set<int> junctions_;
+
  public:
   ReducedGraph(){};
 
@@ -105,8 +108,32 @@ class ReducedGraph : public Graph {
    **/
   std::vector<std::vector<Edge>> expandEdge(const Edge& edge) const;
 
+  /// Get edges
+  std::vector<Edge> getEdges();
+
   /// This method will return a copy of the full graph
   Graph expandGraph();
+
+  /**
+   * \brief Gets the junctions in the graph.
+   *
+   * This method is different from the regular graph method as it must account
+   * for edges that loop around and refer to the same vertex.
+   *
+   * E.g.
+   *
+   *   - -
+   *  |   |
+   *   - -1 - 2 - 3
+   *
+   * This is composed of the edges:
+   * 1, 1
+   * 1, 2
+   * 2, 3
+   *
+   * Thus 1 is the only junction that exists in the reduced graph
+   **/
+  // std::vector<int> getJunctions() const;
 
   std::vector<std::pair<int, GraphNode>> getNodes(void) const;
 

--- a/include/votca/tools/reducedgraph.h
+++ b/include/votca/tools/reducedgraph.h
@@ -110,6 +110,8 @@ class ReducedGraph : public Graph {
 
   std::vector<std::pair<int, GraphNode>> getNodes(void) const;
 
+  std::vector<int> getVertices() const;
+
   std::vector<int> getVerticesDegree(int degree) const;
 
   friend std::ostream& operator<<(std::ostream& os, const ReducedGraph graph);

--- a/include/votca/tools/reducedgraph.h
+++ b/include/votca/tools/reducedgraph.h
@@ -103,12 +103,12 @@ class ReducedGraph : public Graph {
    * vec_edges.at(0); // 2-3
    * vec_edges.at(1); // 2-6, 6-7, 7-3
    **/
-  std::vector<std::vector<Edge>> expandEdge(Edge edge);
+  std::vector<std::vector<Edge>> expandEdge(const Edge& edge) const;
 
   /// This method will return a copy of the full graph
   Graph expandGraph();
 
-  std::vector<std::pair<int, GraphNode>> getNodes(void);
+  std::vector<std::pair<int, GraphNode>> getNodes(void) const;
 
   std::vector<int> getVerticesDegree(int degree) const;
 

--- a/include/votca/tools/reducedgraph.h
+++ b/include/votca/tools/reducedgraph.h
@@ -1,6 +1,6 @@
 /*
  *            E
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")

--- a/src/libtools/edgecontainer.cc
+++ b/src/libtools/edgecontainer.cc
@@ -117,18 +117,22 @@ vector<int> EdgeContainer::getVertices() const {
 
 vector<int> EdgeContainer::getNeighVertices(int vertex) const {
   vector<int> neigh_verts;
-  for (const pair<int, int>& neigh_and_count : adj_list_.at(vertex)) {
-    neigh_verts.push_back(neigh_and_count.first);
+  if (adj_list_.count(vertex)) {
+    for (const pair<int, int>& neigh_and_count : adj_list_.at(vertex)) {
+      neigh_verts.push_back(neigh_and_count.first);
+    }
   }
   return neigh_verts;
 }
 
 vector<Edge> EdgeContainer::getNeighEdges(int vertex) const {
   vector<Edge> neigh_edges;
-  for (const pair<int, int>& neigh_and_count : adj_list_.at(vertex)) {
-    for (int count = 0; count < adj_list_.at(vertex).at(neigh_and_count.first);
-         ++count) {
-      neigh_edges.push_back(Edge(vertex, neigh_and_count.first));
+  if (adj_list_.count(vertex)) {
+    for (const pair<int, int>& neigh_and_count : adj_list_.at(vertex)) {
+      for (int count = 0;
+           count < adj_list_.at(vertex).at(neigh_and_count.first); ++count) {
+        neigh_edges.push_back(Edge(vertex, neigh_and_count.first));
+      }
     }
   }
   return neigh_edges;

--- a/src/libtools/edgecontainer.cc
+++ b/src/libtools/edgecontainer.cc
@@ -18,6 +18,7 @@
  */
 
 #include <algorithm>
+#include <cassert>
 #include <exception>
 #include <set>
 #include <vector>
@@ -51,6 +52,9 @@ int EdgeContainer::getMaxDegree(void) const {
 int EdgeContainer::getDegree(const int vertex) const {
   if (!adj_list_.count(vertex)) throw invalid_argument("vertex is not defined");
   int degree_count = 0;
+  if (adj_list_.at(vertex).size() == 0) {
+    return degree_count;
+  }
   for (const pair<int, int>& neighbor_and_count : adj_list_.at(vertex)) {
     degree_count += neighbor_and_count.second;
   }
@@ -66,6 +70,16 @@ vector<int> EdgeContainer::getVerticesDegree(int degree) const {
     }
   }
   return vertices;
+}
+
+bool EdgeContainer::vertexExistWithDegree(int degree) const {
+  for (const auto& vertex_and_neigh_and_count : adj_list_) {
+    int degree_count = getDegree(vertex_and_neigh_and_count.first);
+    if (degree_count == degree) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool EdgeContainer::edgeExist(const Edge& edge) const {
@@ -107,9 +121,16 @@ void EdgeContainer::addEdge(Edge edge) {
   return;
 }
 
+void EdgeContainer::addVertex(int vertex) {
+  assert(adj_list_.count(vertex) == 0 && "Cannot add vertex already exists");
+  unordered_map<int, int> empty_temp;
+  adj_list_[vertex] = empty_temp;
+}
+
 vector<int> EdgeContainer::getVertices() const {
   vector<int> vertices;
-  for (const auto& vertex_and_neigh_and_count : adj_list_) {
+  for (const pair<const int, unordered_map<int, int>>&
+           vertex_and_neigh_and_count : adj_list_) {
     vertices.push_back(vertex_and_neigh_and_count.first);
   }
   return vertices;

--- a/src/libtools/edgecontainer.cc
+++ b/src/libtools/edgecontainer.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -68,7 +68,7 @@ vector<int> EdgeContainer::getVerticesDegree(int degree) const {
   return vertices;
 }
 
-bool EdgeContainer::edgeExist(Edge edge) const {
+bool EdgeContainer::edgeExist(const Edge& edge) const {
   if (adj_list_.count(edge.getEndPoint1())) {
     if (adj_list_.at(edge.getEndPoint1()).count(edge.getEndPoint2())) {
       return true;
@@ -107,7 +107,7 @@ void EdgeContainer::addEdge(Edge edge) {
   return;
 }
 
-vector<int> EdgeContainer::getVertices() {
+vector<int> EdgeContainer::getVertices() const {
   vector<int> vertices;
   for (const auto& vertex_and_neigh_and_count : adj_list_) {
     vertices.push_back(vertex_and_neigh_and_count.first);
@@ -115,18 +115,18 @@ vector<int> EdgeContainer::getVertices() {
   return vertices;
 }
 
-vector<int> EdgeContainer::getNeighVertices(int vertex) {
+vector<int> EdgeContainer::getNeighVertices(int vertex) const {
   vector<int> neigh_verts;
-  for (const pair<int, int>& neigh_and_count : adj_list_[vertex]) {
+  for (const pair<int, int>& neigh_and_count : adj_list_.at(vertex)) {
     neigh_verts.push_back(neigh_and_count.first);
   }
   return neigh_verts;
 }
 
-vector<Edge> EdgeContainer::getNeighEdges(int vertex) {
+vector<Edge> EdgeContainer::getNeighEdges(int vertex) const {
   vector<Edge> neigh_edges;
-  for (const pair<int, int>& neigh_and_count : adj_list_[vertex]) {
-    for (int count = 0; count < adj_list_[vertex][neigh_and_count.first];
+  for (const pair<int, int>& neigh_and_count : adj_list_.at(vertex)) {
+    for (int count = 0; count < adj_list_.at(vertex).at(neigh_and_count.first);
          ++count) {
       neigh_edges.push_back(Edge(vertex, neigh_and_count.first));
     }

--- a/src/libtools/edgecontainer.cc
+++ b/src/libtools/edgecontainer.cc
@@ -56,7 +56,11 @@ int EdgeContainer::getDegree(const int vertex) const {
     return degree_count;
   }
   for (const pair<int, int>& neighbor_and_count : adj_list_.at(vertex)) {
-    degree_count += neighbor_and_count.second;
+    if (neighbor_and_count.first == vertex) {
+      degree_count += neighbor_and_count.second * 2;
+    } else {
+      degree_count += neighbor_and_count.second;
+    }
   }
   return degree_count;
 }
@@ -110,7 +114,7 @@ void EdgeContainer::addEdge(Edge edge) {
     adj_list_[point1][point2] = 1;
   }
 
-  // Do not add the same edge if the points are the same
+  // Do not add the same edge a second time if the points are the same
   if (point1 != point2) {
     if (adj_list_[point2].count(point1)) {
       ++adj_list_[point2][point1];

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -111,8 +111,8 @@ vector<int> Graph::getJunctions() const {
   return junctions;
 }
 
-void Graph::copyNodes(Graph & graph){
-  for(const pair<int,GraphNode>& id_and_node : graph.nodes_ ){
+void Graph::copyNodes(Graph& graph) {
+  for (const pair<int, GraphNode>& id_and_node : graph.nodes_) {
     cout << "Copying node " << id_and_node.first << endl;
     this->nodes_[id_and_node.first] = id_and_node.second;
   }
@@ -131,31 +131,31 @@ void Graph::calcId_() {
 }
 
 int Graph::getDegree(int vertex) const {
-  if(edge_container_.vertexExist(vertex)){
+  if (edge_container_.vertexExist(vertex)) {
     return edge_container_.getDegree(vertex);
   }
-  if(nodes_.count(vertex)) return 0;
-  throw invalid_argument("vertex does not exist within the graph the degree is "
+  if (nodes_.count(vertex)) return 0;
+  throw invalid_argument(
+      "vertex does not exist within the graph the degree is "
       "not defined.");
-  
 }
 
-bool Graph::vertexExist(int vertex){
-  if(edge_container_.vertexExist(vertex)) return true;
-  if(nodes_.count(vertex)) return true;
+bool Graph::vertexExist(int vertex) {
+  if (edge_container_.vertexExist(vertex)) return true;
+  if (nodes_.count(vertex)) return true;
   return false;
 }
 
 vector<int> Graph::getVerticesDegree(int degree) const {
-  if(degree==0){
+  if (degree == 0) {
     vector<int> vertices;
-    for( const pair<int,GraphNode> id_and_node : nodes_){
-      if(edge_container_.vertexExist(id_and_node.first)==false){
+    for (const pair<int, GraphNode> id_and_node : nodes_) {
+      if (edge_container_.vertexExist(id_and_node.first) == false) {
         vertices.push_back(id_and_node.first);
       }
     }
     return vertices;
-  }else{
+  } else {
     return edge_container_.getVerticesDegree(degree);
   }
 }

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -70,17 +70,6 @@ vector<pair<int, GraphNode>> Graph::getIsolatedNodes(void) const {
   return isolated_nodes;
 }
 
-vector<int> Graph::getVerticesMissingNodes(void) {
-  vector<int> missing;
-  vector<int> vertices = edge_container_.getVertices();
-  for (int& vertex : vertices) {
-    if (nodes_.count(vertex) == 0) {
-      missing.push_back(vertex);
-    }
-  }
-  return missing;
-}
-
 vector<pair<int, GraphNode>> Graph::getNeighNodes(int vertex) const {
   vector<int> neigh_vertices = edge_container_.getNeighVertices(vertex);
   vector<pair<int, GraphNode>> neigh_ids_and_nodes;
@@ -123,6 +112,8 @@ vector<int> Graph::getJunctions() const {
   }
   return junctions;
 }
+
+void Graph::clearNodes() { nodes_.clear(); }
 
 void Graph::copyNodes(Graph& graph) {
   assert(nodes_.size() == 0);

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -112,7 +112,7 @@ vector<int> Graph::getJunctions() const {
 }
 
 void Graph::copyNodes(Graph& graph) {
-  assert(nodes_.size()==0);
+  assert(nodes_.size() == 0);
   for (const pair<int, GraphNode>& id_and_node : graph.nodes_) {
     this->nodes_[id_and_node.first] = id_and_node.second;
   }

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -111,6 +111,14 @@ vector<int> Graph::getJunctions() const {
   return junctions;
 }
 
+void Graph::copyNodes(Graph & graph){
+  for(const pair<int,GraphNode>& id_and_node : graph.nodes_ ){
+    cout << "Copying node " << id_and_node.first << endl;
+    this->nodes_[id_and_node.first] = id_and_node.second;
+  }
+  cout << "Size of nodes after copy " << nodes_.size() << endl;
+}
+
 void Graph::calcId_() {
   auto nodes = getNodes();
   sort(nodes.begin(), nodes.end(), cmpVertNodePair);
@@ -120,6 +128,36 @@ void Graph::calcId_() {
   }
   id_ = struct_Id_temp;
   return;
+}
+
+int Graph::getDegree(int vertex) const {
+  if(edge_container_.vertexExist(vertex)){
+    return edge_container_.getDegree(vertex);
+  }
+  if(nodes_.count(vertex)) return 0;
+  throw invalid_argument("vertex does not exist within the graph the degree is "
+      "not defined.");
+  
+}
+
+bool Graph::vertexExist(int vertex){
+  if(edge_container_.vertexExist(vertex)) return true;
+  if(nodes_.count(vertex)) return true;
+  return false;
+}
+
+vector<int> Graph::getVerticesDegree(int degree) const {
+  if(degree==0){
+    vector<int> vertices;
+    for( const pair<int,GraphNode> id_and_node : nodes_){
+      if(edge_container_.vertexExist(id_and_node.first)==false){
+        vertices.push_back(id_and_node.first);
+      }
+    }
+    return vertices;
+  }else{
+    return edge_container_.getVerticesDegree(degree);
+  }
 }
 
 ostream& operator<<(ostream& os, const Graph graph) {

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -112,6 +112,7 @@ vector<int> Graph::getJunctions() const {
 }
 
 void Graph::copyNodes(Graph& graph) {
+  assert(nodes_.size()==0);
   for (const pair<int, GraphNode>& id_and_node : graph.nodes_) {
     this->nodes_[id_and_node.first] = id_and_node.second;
   }

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -113,10 +113,8 @@ vector<int> Graph::getJunctions() const {
 
 void Graph::copyNodes(Graph& graph) {
   for (const pair<int, GraphNode>& id_and_node : graph.nodes_) {
-    cout << "Copying node " << id_and_node.first << endl;
     this->nodes_[id_and_node.first] = id_and_node.second;
   }
-  cout << "Size of nodes after copy " << nodes_.size() << endl;
 }
 
 void Graph::calcId_() {

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -74,7 +74,7 @@ vector<pair<int, GraphNode>> Graph::getNeighNodes(int vertex) {
   return neigh_ids_and_nodes;
 }
 
-void Graph::setNode(int vertex, GraphNode graph_node) {
+void Graph::setNode(int vertex, GraphNode& graph_node) {
   if (nodes_.count(vertex)) {
     nodes_[vertex] = graph_node;
   } else {
@@ -84,13 +84,13 @@ void Graph::setNode(int vertex, GraphNode graph_node) {
   calcId_();
 }
 
-void Graph::setNode(std::pair<int, GraphNode> id_and_node) {
+void Graph::setNode(std::pair<int, GraphNode>& id_and_node) {
   setNode(id_and_node.first, id_and_node.second);
 }
 
-GraphNode Graph::getNode(int vertex) {
+GraphNode Graph::getNode(const int vertex) const {
   assert(nodes_.count(vertex));
-  return nodes_[vertex];
+  return nodes_.at(vertex);
 }
 
 vector<pair<int, GraphNode>> Graph::getNodes(void) {

--- a/src/libtools/graph.cc
+++ b/src/libtools/graph.cc
@@ -35,7 +35,7 @@ bool Graph::operator!=(const Graph& graph) const {
 
 bool Graph::operator==(const Graph& graph) const { return !(*(this) != graph); }
 
-vector<pair<int, GraphNode>> Graph::getIsolatedNodes(void) {
+vector<pair<int, GraphNode>> Graph::getIsolatedNodes(void) const {
   vector<pair<int, GraphNode>> isolated_nodes;
   for (const pair<int, GraphNode>& id_and_node : nodes_) {
     if (edge_container_.vertexExist(id_and_node.first)) {
@@ -64,11 +64,11 @@ vector<int> Graph::getVerticesMissingNodes(void) {
   return missing;
 }
 
-vector<pair<int, GraphNode>> Graph::getNeighNodes(int vertex) {
+vector<pair<int, GraphNode>> Graph::getNeighNodes(int vertex) const {
   vector<int> neigh_vertices = edge_container_.getNeighVertices(vertex);
   vector<pair<int, GraphNode>> neigh_ids_and_nodes;
-  for (int& neigh_vert : neigh_vertices) {
-    auto id_and_node = pair<int, GraphNode>(neigh_vert, nodes_[neigh_vert]);
+  for (const int& neigh_vert : neigh_vertices) {
+    auto id_and_node = pair<int, GraphNode>(neigh_vert, nodes_.at(neigh_vert));
     neigh_ids_and_nodes.push_back(id_and_node);
   }
   return neigh_ids_and_nodes;
@@ -93,7 +93,7 @@ GraphNode Graph::getNode(const int vertex) const {
   return nodes_.at(vertex);
 }
 
-vector<pair<int, GraphNode>> Graph::getNodes(void) {
+vector<pair<int, GraphNode>> Graph::getNodes(void) const {
   vector<pair<int, GraphNode>> vec_nodes;
   for (const pair<int, GraphNode>& id_and_node : nodes_) {
     vec_nodes.push_back(id_and_node);
@@ -139,7 +139,7 @@ int Graph::getDegree(int vertex) const {
       "not defined.");
 }
 
-bool Graph::vertexExist(int vertex) {
+bool Graph::vertexExist(int vertex) const {
   if (edge_container_.vertexExist(vertex)) return true;
   if (nodes_.count(vertex)) return true;
   return false;

--- a/src/libtools/graph_bf_visitor.cc
+++ b/src/libtools/graph_bf_visitor.cc
@@ -29,7 +29,7 @@ namespace tools {
 
 bool Graph_BF_Visitor::queEmpty() const { return edge_que_.empty(); }
 
-Edge Graph_BF_Visitor::getEdge_(Graph graph) {
+Edge Graph_BF_Visitor::getEdge_(const Graph& graph) {
   Edge oldest_edge = edge_que_.at(0).front();
   edge_que_.at(0).pop();
   if (edge_que_.at(0).size() == 0) {
@@ -39,7 +39,7 @@ Edge Graph_BF_Visitor::getEdge_(Graph graph) {
 }
 
 // Add edges to be explored
-void Graph_BF_Visitor::addEdges_(Graph& graph, int vertex) {
+void Graph_BF_Visitor::addEdges_(const Graph& graph, int vertex) {
 
   vector<Edge> newest_edges = graph.getNeighEdges(vertex);
 

--- a/src/libtools/graph_df_visitor.cc
+++ b/src/libtools/graph_df_visitor.cc
@@ -27,16 +27,16 @@ using namespace std;
 namespace votca {
 namespace tools {
 
-bool Graph_DF_Visitor::queEmpty() const { return edge_stack_.empty(); }
+bool Graph_DF_Visitor::queEmpty() const { return edge_list_.empty(); }
 
-Edge Graph_DF_Visitor::getEdge_(Graph g) {
+Edge Graph_DF_Visitor::getEdge_(const Graph& g) {
   Edge ed = edge_list_.back();
   edge_list_.pop_back();
   return ed;
 }
 
 // Add edges to be explored
-void Graph_DF_Visitor::addEdges_(Graph& g, int vertex) {
+void Graph_DF_Visitor::addEdges_(const Graph& g, int vertex) {
   auto eds = g.getNeighEdges(vertex);
   if (edge_list_.empty()) {
     // If first edges to be added

--- a/src/libtools/graph_df_visitor.cc
+++ b/src/libtools/graph_df_visitor.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -38,30 +38,31 @@ Edge Graph_DF_Visitor::getEdge_(Graph g) {
 // Add edges to be explored
 void Graph_DF_Visitor::addEdges_(Graph& g, int vertex) {
   auto eds = g.getNeighEdges(vertex);
-  if(edge_list_.empty()){
-  // If first edges to be added
-    for(auto ed : eds){
+  if (edge_list_.empty()) {
+    // If first edges to be added
+    for (auto ed : eds) {
       int neigh_vert = ed.getOtherEndPoint(vertex);
-      if(explored_.count(neigh_vert)==0){
+      if (explored_.count(neigh_vert) == 0) {
         edge_list_.push_back(ed);
       }
     }
-  }else{
-    for(const auto& ed : eds){
+  } else {
+    for (const auto& ed : eds) {
       int neigh_vert = ed.getOtherEndPoint(vertex);
-      if(explored_.count(neigh_vert)==0){
+      if (explored_.count(neigh_vert) == 0) {
         edge_list_.push_back(ed);
-      }else{
+      } else {
         // Check if edge has already been added earlier in the queue
         // if so we wil move it to the end
-        list<Edge>::iterator edge_found_iterator = find(edge_list_.begin(),edge_list_.end(),ed);
-        if(edge_found_iterator!=edge_list_.end()){
+        list<Edge>::iterator edge_found_iterator =
+            find(edge_list_.begin(), edge_list_.end(), ed);
+        if (edge_found_iterator != edge_list_.end()) {
           // Move the edge to the back if it was stored earlier on.
-          edge_list_.splice(edge_list_.end(),edge_list_,edge_found_iterator); 
+          edge_list_.splice(edge_list_.end(), edge_list_, edge_found_iterator);
         }
       }
     }
   }
 }
-}
-}
+}  // namespace tools
+}  // namespace votca

--- a/src/libtools/graph_df_visitor.cc
+++ b/src/libtools/graph_df_visitor.cc
@@ -16,7 +16,7 @@
  * limitations under the License.
  *
  */
-
+#include <algorithm>
 #include <votca/tools/edge.h>
 #include <votca/tools/graph.h>
 #include <votca/tools/graph_df_visitor.h>
@@ -27,30 +27,38 @@ using namespace std;
 namespace votca {
 namespace tools {
 
-bool Graph_DF_Visitor::queEmpty() { return edge_stack_.empty(); }
+bool Graph_DF_Visitor::queEmpty() { return edge_list_.empty(); }
 
 Edge Graph_DF_Visitor::getEdge_(Graph g) {
-  Edge ed = edge_stack_.top();
-  edge_stack_.pop();
+  Edge ed = edge_list_.back();
+  edge_list_.pop_back();
   return ed;
 }
 
 // Add edges to be explored
 void Graph_DF_Visitor::addEdges_(Graph& g, int vertex) {
   auto eds = g.getNeighEdges(vertex);
-  if(edge_stack_.empty()){
+  if(edge_list_.empty()){
   // If first edges to be added
     for(auto ed : eds){
       int neigh_vert = ed.getOtherEndPoint(vertex);
       if(explored_.count(neigh_vert)==0){
-        edge_stack_.push(ed);
+        edge_list_.push_back(ed);
       }
     }
   }else{
-    for(auto ed : eds){
+    for(const auto& ed : eds){
       int neigh_vert = ed.getOtherEndPoint(vertex);
       if(explored_.count(neigh_vert)==0){
-        edge_stack_.push(ed);
+        edge_list_.push_back(ed);
+      }else{
+        // Check if edge has already been added earlier in the queue
+        // if so we wil move it to the end
+        list<Edge>::iterator edge_found_iterator = find(edge_list_.begin(),edge_list_.end(),ed);
+        if(edge_found_iterator!=edge_list_.end()){
+          // Move the edge to the back if it was stored earlier on.
+          edge_list_.splice(edge_list_.end(),edge_list_,edge_found_iterator); 
+        }
       }
     }
   }

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -49,15 +49,14 @@ vector<Edge> edgeSetToVector_(set<Edge> edges) {
  * Public Functions *
  ********************/
 
-bool singleNetwork(const Graph& graph, GraphVisitor& graph_visitor) {
+bool singleNetwork(Graph graph, GraphVisitor& graph_visitor) {
   exploreGraph(graph, graph_visitor);
   return graph_visitor.getExploredVertices().size() ==
              graph.getVertices().size() &&
          graph.getIsolatedNodes().size() == 0;
 }
 
-std::set<Edge> exploreBranch(const Graph& g, const int starting_vertex,
-                             const Edge& edge) {
+std::set<Edge> exploreBranch(Graph g, int starting_vertex, const Edge& edge) {
   // Check if the starting vertex is in the graph
   if (!g.vertexExist(starting_vertex)) {
     throw invalid_argument(
@@ -108,7 +107,7 @@ std::set<Edge> exploreBranch(const Graph& g, const int starting_vertex,
   return branch_edges;
 }
 
-ReducedGraph reduceGraph(const Graph& graph) {
+ReducedGraph reduceGraph(Graph graph) {
 
   /****************************
    * Internal Function Class
@@ -247,17 +246,15 @@ ReducedGraph reduceGraph(const Graph& graph) {
   return reduced_g;
 }
 
-vector<Graph> decoupleIsolatedSubGraphs(const Graph& graph) {
+vector<Graph> decoupleIsolatedSubGraphs(Graph graph) {
 
   list<int> vertices_list = vectorToList_(graph.getVertices());
   vector<Graph> subGraphs;
-  {
-    Graph_BF_Visitor graph_visitor_breadth_first;
-    graph_visitor_breadth_first.setStartingVertex(*vertices_list.begin());
-    if (singleNetwork(graph, graph_visitor_breadth_first)) {
-      subGraphs.push_back(graph);
-      return subGraphs;
-    }
+  Graph_BF_Visitor graph_visitor_breadth_first;
+  graph_visitor_breadth_first.setStartingVertex(vertices_list.front());
+  if (singleNetwork(graph, graph_visitor_breadth_first)) {
+    subGraphs.push_back(graph);
+    return subGraphs;
   }
 
   list<int>::iterator vertices_iterator = vertices_list.begin();
@@ -298,7 +295,7 @@ vector<Graph> decoupleIsolatedSubGraphs(const Graph& graph) {
   return subGraphs;
 }
 
-void exploreGraph(const Graph& graph, GraphVisitor& graph_visitor) {
+void exploreGraph(Graph& graph, GraphVisitor& graph_visitor) {
 
   if (!graph.vertexExist(graph_visitor.getStartingVertex())) {
     string err = "Cannot explore graph starting at vertex " +

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -71,6 +71,12 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
     throw invalid_argument("The edge determining which branch to explore does "
         "not contain the starting vertex.");
   }
+
+  set<Edge> branch_edges;
+  if(edge.getEndPoint1()==edge.getEndPoint2()){
+    branch_edges.insert(edge);
+    return branch_edges;  
+  }
   Graph_BF_Visitor gv_breadth_first;
   GraphNode gn;
   pair<int,GraphNode> pr_gn(starting_vertex,gn);
@@ -78,7 +84,6 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
   gv_breadth_first.setStartingVertex(edge.getOtherEndPoint(starting_vertex));
   gv_breadth_first.initialize(g);
 
-  set<Edge> branch_edges;
   branch_edges.insert(edge);
   while (!gv_breadth_first.queEmpty()) {
     Edge ed = gv_breadth_first.nextEdge(g);
@@ -89,8 +94,11 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
   vector<Edge> neigh_edges = g.getNeighEdges(starting_vertex);
   for( auto ed : neigh_edges){
     int neigh_vertex = ed.getOtherEndPoint(starting_vertex);
-    if(gv_breadth_first.vertexExplored(neigh_vertex)){
-      branch_edges.insert(ed);
+    if(neigh_vertex!=starting_vertex){
+      cout << "vertex neighboring starting vertex that has been explored " << neigh_vertex << endl;
+      if(gv_breadth_first.vertexExplored(neigh_vertex)){
+        branch_edges.insert(ed);
+      }
     }
   }
 
@@ -227,6 +235,11 @@ ReducedGraph reduceGraph(Graph graph) {
   cout << "Number of reduced edges " << reduced_edges.size() << endl;
 
   ReducedGraph reduced_g(reduced_edges);
+  auto nodes_graph = graph.getNodes();
+  cout << "number of nodes in graph " << nodes_graph.size() << endl;
+  reduced_g.copyNodes(graph);
+  auto nodes_reduced_g = reduced_g.getNodes();
+  cout << "number of nodes in reduced g " << nodes_reduced_g.size() << endl;
   return reduced_g;
 }
 

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -239,15 +239,15 @@ ReducedGraph reduceGraph(Graph graph) {
   return reduced_g;
 }
 
-vector<shared_ptr<Graph>> decoupleIsolatedSubGraphs(Graph graph) {
+vector<Graph> decoupleIsolatedSubGraphs(Graph graph) {
 
   list<int> vertices_list = vectorToList_(graph.getVertices());
-  vector<shared_ptr<Graph>> subGraphs;
+  vector<Graph> subGraphs;
   {
     Graph_BF_Visitor graph_visitor_breadth_first;
     graph_visitor_breadth_first.setStartingVertex(*vertices_list.begin());
     if (singleNetwork(graph, graph_visitor_breadth_first)) {
-      subGraphs.push_back(make_shared<Graph>(graph));
+      subGraphs.push_back(graph);
       return subGraphs;
     }
   }
@@ -285,8 +285,7 @@ vector<shared_ptr<Graph>> decoupleIsolatedSubGraphs(Graph graph) {
 
     vector<Edge> sub_graph_vector_edges = edgeSetToVector_(sub_graph_edges);
 
-    subGraphs.push_back(
-        make_shared<Graph>(Graph(sub_graph_vector_edges, sub_graph_nodes)));
+    subGraphs.push_back(Graph(sub_graph_vector_edges, sub_graph_nodes));
   }
   return subGraphs;
 }

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -247,13 +247,11 @@ ReducedGraph reduceGraph(Graph graph) {
 
 vector<Graph> decoupleIsolatedSubGraphs(Graph graph) {
 
-  cout << "Calling decoupleIsolatedSubGraphs" << endl;
   list<int> vertices_list = vectorToList_(graph.getVertices());
   vector<Graph> subGraphs;
   Graph_BF_Visitor graph_visitor_breadth_first;
   graph_visitor_breadth_first.setStartingVertex(vertices_list.front());
   if (singleNetwork(graph, graph_visitor_breadth_first)) {
-    cout << "Is considered a single network " << endl;
     subGraphs.push_back(graph);
     return subGraphs;
   }
@@ -284,15 +282,12 @@ vector<Graph> decoupleIsolatedSubGraphs(Graph graph) {
       vector<Edge> sub_graph_neigh_edges =
           graph.getNeighEdges(*sub_graph_vertex_it);
       for (const Edge sub_graph_edge : sub_graph_neigh_edges) {
-        cout << "Getting edge " << sub_graph_edge << endl;
         sub_graph_edges.insert(sub_graph_edge);
       }
-      cout << "Getting node " << *sub_graph_vertex_it << endl;
       sub_graph_nodes[*sub_graph_vertex_it] =
           graph.getNode(*sub_graph_vertex_it);
       ++sub_graph_vertex_it;
     }
-    cout << "End of subgraph " << endl;
     vector<Edge> sub_graph_vector_edges = edgeSetToVector_(sub_graph_edges);
     Graph graph_temp(sub_graph_vector_edges, sub_graph_nodes);
     subGraphs.push_back(graph_temp);

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -56,31 +56,34 @@ bool singleNetwork(Graph graph, GraphVisitor& graph_visitor) {
          graph.getIsolatedNodes().size() == 0;
 }
 
-std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
+std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge) {
   // Check if the starting vertex is in the graph
-  if(!g.vertexExist(starting_vertex)){
-    throw invalid_argument("Cannot explore a branch of the graph when the "
+  if (!g.vertexExist(starting_vertex)) {
+    throw invalid_argument(
+        "Cannot explore a branch of the graph when the "
         "exploration is started from a vertex that does not exist within the "
         "graph.");
-  } 
-  if(!g.edgeExist(edge)){
-    throw invalid_argument("Edge does not exist in the graph so exploration of"
+  }
+  if (!g.edgeExist(edge)) {
+    throw invalid_argument(
+        "Edge does not exist in the graph so exploration of"
         " the graph branch cannot continue");
   }
-  if(!edge.contains(starting_vertex)){
-    throw invalid_argument("The edge determining which branch to explore does "
+  if (!edge.contains(starting_vertex)) {
+    throw invalid_argument(
+        "The edge determining which branch to explore does "
         "not contain the starting vertex.");
   }
 
   set<Edge> branch_edges;
-  if(edge.getEndPoint1()==edge.getEndPoint2()){
+  if (edge.getEndPoint1() == edge.getEndPoint2()) {
     branch_edges.insert(edge);
-    return branch_edges;  
+    return branch_edges;
   }
   Graph_BF_Visitor gv_breadth_first;
   GraphNode gn;
-  pair<int,GraphNode> pr_gn(starting_vertex,gn);
-  gv_breadth_first.exploreNode(pr_gn,g);
+  pair<int, GraphNode> pr_gn(starting_vertex, gn);
+  gv_breadth_first.exploreNode(pr_gn, g);
   gv_breadth_first.setStartingVertex(edge.getOtherEndPoint(starting_vertex));
   gv_breadth_first.initialize(g);
 
@@ -92,11 +95,12 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge){
   }
 
   vector<Edge> neigh_edges = g.getNeighEdges(starting_vertex);
-  for( auto ed : neigh_edges){
+  for (auto ed : neigh_edges) {
     int neigh_vertex = ed.getOtherEndPoint(starting_vertex);
-    if(neigh_vertex!=starting_vertex){
-      cout << "vertex neighboring starting vertex that has been explored " << neigh_vertex << endl;
-      if(gv_breadth_first.vertexExplored(neigh_vertex)){
+    if (neigh_vertex != starting_vertex) {
+      cout << "vertex neighboring starting vertex that has been explored "
+           << neigh_vertex << endl;
+      if (gv_breadth_first.vertexExplored(neigh_vertex)) {
         branch_edges.insert(ed);
       }
     }

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -98,8 +98,6 @@ std::set<Edge> exploreBranch(Graph g, int starting_vertex, Edge edge) {
   for (auto ed : neigh_edges) {
     int neigh_vertex = ed.getOtherEndPoint(starting_vertex);
     if (neigh_vertex != starting_vertex) {
-      cout << "vertex neighboring starting vertex that has been explored "
-           << neigh_vertex << endl;
       if (gv_breadth_first.vertexExplored(neigh_vertex)) {
         branch_edges.insert(ed);
       }
@@ -184,14 +182,10 @@ ReducedGraph reduceGraph(Graph graph) {
     graph_visitor.initialize(graph);
 
     vector<int> chain{starting_vertex};
-    cout << endl;
-    cout << "Starting vertex is " << starting_vertex << endl;
     int old_vertex = starting_vertex;
     bool new_chain = false;
     while (!graph_visitor.queEmpty()) {
       Edge edge = graph_visitor.nextEdge(graph);
-      cout << "Exploring edge " << endl;
-      cout << edge << endl;
       vector<int> unexplored_vertex = graph_visitor.getUnexploredVertex(edge);
 
       if (new_chain) {
@@ -206,12 +200,10 @@ ReducedGraph reduceGraph(Graph graph) {
         }
       }
       int new_vertex = edge.getOtherEndPoint(old_vertex);
-      cout << "Exploring new_vertex " << new_vertex << endl;
       if (unexplored_vertex.size() == 0) {
         chain.push_back(new_vertex);
         chains.push_back(chain);
         chain.clear();
-        cout << "Added chain 1" << endl;
         new_chain = true;
       } else if (graph.getDegree(new_vertex) == 1) {
         chain.push_back(new_vertex);
@@ -219,19 +211,16 @@ ReducedGraph reduceGraph(Graph graph) {
         chain.clear();
         exploration_record.explore(new_vertex);
         new_chain = true;
-        cout << "Added chain 2" << endl;
       } else if (graph.getDegree(new_vertex) > 2) {
         chain.push_back(new_vertex);
         chains.push_back(chain);
         chain.clear();
         exploration_record.explore(new_vertex);
         new_chain = true;
-        cout << "Added chain 3" << endl;
       } else if (unexplored_vertex.size() == 1) {
         chain.push_back(new_vertex);
         old_vertex = new_vertex;
         exploration_record.explore(new_vertex);
-        cout << "Just adding vertex to chain " << endl;
       }
 
       graph_visitor.exec(graph, edge);
@@ -243,14 +232,10 @@ ReducedGraph reduceGraph(Graph graph) {
     reduced_edges.push_back(reduced_edge);
   }
 
-  cout << "Number of reduced edges " << reduced_edges.size() << endl;
-
   ReducedGraph reduced_g(reduced_edges);
   auto nodes_graph = graph.getNodes();
-  cout << "number of nodes in graph " << nodes_graph.size() << endl;
   reduced_g.copyNodes(graph);
   auto nodes_reduced_g = reduced_g.getNodes();
-  cout << "number of nodes in reduced g " << nodes_reduced_g.size() << endl;
   return reduced_g;
 }
 

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -48,8 +48,7 @@ vector<Edge> edgeSetToVector_(set<Edge> edges) {
 /********************
  * Public Functions *
  ********************/
-
-bool singleNetwork(Graph graph, GraphVisitor& graph_visitor) {
+bool singleNetwork(Graph& graph, GraphVisitor& graph_visitor) {
   exploreGraph(graph, graph_visitor);
   return graph_visitor.getExploredVertices().size() ==
              graph.getVertices().size() &&
@@ -248,22 +247,23 @@ ReducedGraph reduceGraph(Graph graph) {
 
 vector<Graph> decoupleIsolatedSubGraphs(Graph graph) {
 
+  cout << "Calling decoupleIsolatedSubGraphs" << endl;
   list<int> vertices_list = vectorToList_(graph.getVertices());
   vector<Graph> subGraphs;
   Graph_BF_Visitor graph_visitor_breadth_first;
   graph_visitor_breadth_first.setStartingVertex(vertices_list.front());
   if (singleNetwork(graph, graph_visitor_breadth_first)) {
+    cout << "Is considered a single network " << endl;
     subGraphs.push_back(graph);
     return subGraphs;
   }
 
   list<int>::iterator vertices_iterator = vertices_list.begin();
-  unordered_map<int, GraphNode> sub_graph_nodes;
   while (vertices_iterator != vertices_list.end()) {
+    unordered_map<int, GraphNode> sub_graph_nodes;
     Graph_BF_Visitor graph_visitor_breadth_first;
     graph_visitor_breadth_first.setStartingVertex(*vertices_iterator);
     exploreGraph(graph, graph_visitor_breadth_first);
-
     ++vertices_iterator;
     set<int> sub_graph_explored_vertices =
         graph_visitor_breadth_first.getExploredVertices();
@@ -271,26 +271,31 @@ vector<Graph> decoupleIsolatedSubGraphs(Graph graph) {
 
     set<int>::iterator sub_graph_vertex_it =
         sub_graph_explored_vertices.begin();
+
+    // Means it is an isolated node
+
     while (sub_graph_vertex_it != sub_graph_explored_vertices.end()) {
       if (*vertices_iterator == *sub_graph_vertex_it) {
         ++vertices_iterator;
       }
+
       vertices_list.remove(*sub_graph_vertex_it);
 
       vector<Edge> sub_graph_neigh_edges =
           graph.getNeighEdges(*sub_graph_vertex_it);
       for (const Edge sub_graph_edge : sub_graph_neigh_edges) {
+        cout << "Getting edge " << sub_graph_edge << endl;
         sub_graph_edges.insert(sub_graph_edge);
       }
-
+      cout << "Getting node " << *sub_graph_vertex_it << endl;
       sub_graph_nodes[*sub_graph_vertex_it] =
           graph.getNode(*sub_graph_vertex_it);
       ++sub_graph_vertex_it;
     }
-
+    cout << "End of subgraph " << endl;
     vector<Edge> sub_graph_vector_edges = edgeSetToVector_(sub_graph_edges);
-
-    subGraphs.push_back(Graph(sub_graph_vector_edges, sub_graph_nodes));
+    Graph graph_temp(sub_graph_vector_edges, sub_graph_nodes);
+    subGraphs.push_back(graph_temp);
   }
   return subGraphs;
 }

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -184,11 +184,14 @@ ReducedGraph reduceGraph(Graph graph) {
     graph_visitor.initialize(graph);
 
     vector<int> chain{starting_vertex};
+    cout << endl;
+    cout << "Starting vertex is " << starting_vertex << endl;
     int old_vertex = starting_vertex;
     bool new_chain = false;
     while (!graph_visitor.queEmpty()) {
       Edge edge = graph_visitor.nextEdge(graph);
-
+      cout << "Exploring edge " << endl;
+      cout << edge << endl;
       vector<int> unexplored_vertex = graph_visitor.getUnexploredVertex(edge);
 
       if (new_chain) {
@@ -203,11 +206,12 @@ ReducedGraph reduceGraph(Graph graph) {
         }
       }
       int new_vertex = edge.getOtherEndPoint(old_vertex);
-
+      cout << "Exploring new_vertex " << new_vertex << endl;
       if (unexplored_vertex.size() == 0) {
         chain.push_back(new_vertex);
         chains.push_back(chain);
         chain.clear();
+        cout << "Added chain 1" << endl;
         new_chain = true;
       } else if (graph.getDegree(new_vertex) == 1) {
         chain.push_back(new_vertex);
@@ -215,16 +219,19 @@ ReducedGraph reduceGraph(Graph graph) {
         chain.clear();
         exploration_record.explore(new_vertex);
         new_chain = true;
+        cout << "Added chain 2" << endl;
       } else if (graph.getDegree(new_vertex) > 2) {
         chain.push_back(new_vertex);
         chains.push_back(chain);
         chain.clear();
         exploration_record.explore(new_vertex);
         new_chain = true;
+        cout << "Added chain 3" << endl;
       } else if (unexplored_vertex.size() == 1) {
         chain.push_back(new_vertex);
         old_vertex = new_vertex;
         exploration_record.explore(new_vertex);
+        cout << "Just adding vertex to chain " << endl;
       }
 
       graph_visitor.exec(graph, edge);

--- a/src/libtools/graphalgorithm.cc
+++ b/src/libtools/graphalgorithm.cc
@@ -240,6 +240,7 @@ ReducedGraph reduceGraph(Graph graph) {
 
   ReducedGraph reduced_g(reduced_edges);
   auto nodes_graph = graph.getNodes();
+  reduced_g.clearNodes();
   reduced_g.copyNodes(graph);
   auto nodes_reduced_g = reduced_g.getNodes();
   return reduced_g;

--- a/src/libtools/graphvisitor.cc
+++ b/src/libtools/graphvisitor.cc
@@ -90,6 +90,7 @@ Edge GraphVisitor::getEdge_(const Graph& graph) {
 Edge GraphVisitor::nextEdge(Graph graph) {
 
   // Get the edge and at the same time remove it from whatever queue it is in
+
   Edge edge = getEdge_(graph);
   vector<int> unexplored_vertices = getUnexploredVertex(edge);
   // Do not add neighboring edges if they belong to a vertex that has already

--- a/src/libtools/graphvisitor.cc
+++ b/src/libtools/graphvisitor.cc
@@ -33,10 +33,6 @@ class GraphNode;
 
 bool GraphVisitor::queEmpty() const { return true; }
 
-void GraphVisitor::addEdges_(const Graph& graph, int vertex) {
-  throw runtime_error("addEdges_ method must be defined by your visitor");
-}
-
 void GraphVisitor::exploreNode(pair<int, GraphNode>& vertex_and_node,
                                Graph& graph, Edge edge) {
   explored_.insert(vertex_and_node.first);
@@ -81,10 +77,6 @@ void GraphVisitor::exec(Graph& graph, Edge edge) {
                                        graph.getNode(unexp_vert.at(0)));
 
   exploreNode(vertex_and_node, graph, edge);
-}
-
-Edge GraphVisitor::getEdge_(const Graph& graph) {
-  throw runtime_error("The getEdge_ function must be set");
 }
 
 Edge GraphVisitor::nextEdge(Graph graph) {

--- a/src/libtools/graphvisitor.cc
+++ b/src/libtools/graphvisitor.cc
@@ -33,7 +33,7 @@ class GraphNode;
 
 bool GraphVisitor::queEmpty() const { return true; }
 
-void GraphVisitor::addEdges_(Graph& graph, int vertex) {
+void GraphVisitor::addEdges_(const Graph& graph, int vertex) {
   throw runtime_error("addEdges_ method must be defined by your visitor");
 }
 
@@ -83,7 +83,7 @@ void GraphVisitor::exec(Graph& graph, Edge edge) {
   exploreNode(vertex_and_node, graph, edge);
 }
 
-Edge GraphVisitor::getEdge_(Graph graph) {
+Edge GraphVisitor::getEdge_(const Graph& graph) {
   throw runtime_error("The getEdge_ function must be set");
 }
 

--- a/src/libtools/reducedgraph.cc
+++ b/src/libtools/reducedgraph.cc
@@ -29,6 +29,14 @@ namespace tools {
 
 class GraphNode;
 
+/**
+ * \brief Function will compare a chain with a vector of chains
+ *
+ * If the one of the chains in the vector of chains is equivalent will return
+ * true. A chain is simply a vector of integers where each integer represents
+ * a vertex along an edge. The vertices appear in the chain in the same order
+ * as they exist in a graph.
+ **/
 bool compareChainWithChains_(const vector<int>& chain,
                              const vector<vector<int>>& chains) {
   bool match = false;
@@ -47,6 +55,36 @@ bool compareChainWithChains_(const vector<int>& chain,
   return false;
 }
 
+/**
+ * \brief Given a vector of Reduced Edges will find and return junctions if any
+ * exist
+ *
+ * A junction is a vertex in a graph that has 3 or more edges eminating from it.
+ *
+ * Consider three reduced edges given by
+ *
+ * Edge   Reduced Edge when Expanded (chain of vertices)
+ * 1, 5  :  1 - 3 - 4 - 6 - 5
+ * 5, 10 :  5 - 2 - 10
+ * 5, 9  :  5 - 8 - 9
+ *
+ * Graph:
+ *
+ * 1 - 3 - 4 - 6 - 5 - 2 - 10
+ *                 |
+ *                 8 - 9
+ *
+ * Reduced Graph:
+ *
+ * 1 - 5 - 10
+ *     |
+ *     9
+ *
+ * Here vertex 5 would be found to be a junction
+ *
+ * @param[in,out] - vector of reduced edges
+ * @return - set of integers containing junctions
+ **/
 set<int> getVertexJunctions_(const vector<ReducedEdge>& reduced_edges) {
   unordered_map<int, int> vertex_count;
   for (ReducedEdge reduced_edge : reduced_edges) {
@@ -76,6 +114,34 @@ set<int> getVertexJunctions_(const vector<ReducedEdge>& reduced_edges) {
   return junctions;
 }
 
+/**
+ * \breif function adds an edge to an unordered_map and a vector if it is found
+ * to not be a loop
+ *
+ * A loop is an edge that essentially makes a circle. In an edge that is a loop
+ * will have both end points equal to the samve vertex. E.g. a reduced edge
+ * like this:
+ *
+ * Edge  Expanded edge (chain of vertices)
+ * 2, 2 : 2 - 4 - 3 - 5 - 2
+ *
+ * Graph
+ *
+ *  2 - 4
+ *  |   |
+ *  5 - 3
+ *
+ * Reduced Graph
+ *
+ *  - 2
+ *  |_|
+ *
+ * @param[in,out] - vector of edges, an edge is added to the vector if it is not
+ * a loop
+ * @param[in] - a reduced edge, the edge to be added
+ * @param[in,out] - an unordered_map that stores the edge and its chain if it
+ * is found to not be a loop
+ **/
 void addEdgeIfNotLoop_(
     vector<Edge>& edges, const ReducedEdge reduced_edge,
     unordered_map<Edge, vector<vector<int>>>& expanded_edges) {
@@ -93,6 +159,30 @@ void addEdgeIfNotLoop_(
   edges.push_back(edge);
 }
 
+/**
+ * \brief This is a helper function used to help store the vertex chain in a
+ * reproducable order
+ *
+ * Ordering chains in a reproducable manner enable quicker comparison between
+ * chains.
+ *
+ * E.g. Given a chain
+ *
+ * End Point 1
+ * v
+ * 1 - 4 - 3 - 5 - 6 - 2 - 1
+ *                         ^
+ *                      End Point 2
+ *
+ * This function will ensure that it is reordered such that the next consecutive
+ * number in the chain after end point 2 is the lower number, in this case the
+ * two numbers that are compared are 4 and 2. The 2 is smaller so the chain is
+ * reordered.
+ *
+ * 1 - 2 - 6 - 5 - 3 - 4 - 1
+ *
+ * @param[in,out] - vector of integers containing the chain
+ **/
 void orderChainAfterInitialVertex_(vector<int>& chain) {
   size_t ignore_first_and_last_vertex = 2;
   size_t total_number_to_parse =
@@ -110,7 +200,7 @@ void orderChainAfterInitialVertex_(vector<int>& chain) {
   }
 }
 
-bool reordereAndStoreChainIfDoesNotExist_(
+bool reorderAndStoreChainIfDoesNotExist_(
     vector<Edge>& edges,
     unordered_map<Edge, vector<vector<int>>>& expanded_edges, vector<int> chain,
     int vertex, size_t& chain_index) {
@@ -152,7 +242,7 @@ void ReducedGraph::init_(vector<ReducedEdge> reduced_edges,
       bool edge_added = false;
       for (int vertex : chain) {
         if (junctions_.count(vertex)) {
-          edge_added = reordereAndStoreChainIfDoesNotExist_(
+          edge_added = reorderAndStoreChainIfDoesNotExist_(
               edges, expanded_edges_, chain, vertex, chain_index);
           break;
         }
@@ -271,35 +361,6 @@ vector<pair<int, GraphNode>> ReducedGraph::getNodes() const {
     }
   }
   return nodes;
-}
-/*
-bool ReducedGraph::edgeExist(const Edge& edge) const {
-  return edge_container_.edgeExist(edge);
-}*/
-
-vector<Edge> ReducedGraph::getEdges() {
-  /*  vector<Edge> edges_unfiltered = edge_container_.getEdges();
-    vector<Edge> edges;
-    for(const Edge edge : edges_unfiltered){
-     if(edge.loop()){
-      // Find which vertex if any is a junction if it is return the edge so that
-      // it points to the junction
-      vector<vector<int>> chains = expanded_edges_.at(edge);
-      // If it is a loop there should only be a single junction at most
-      assert(chains.size()==1);
-      for(int vertex : chains.at(0)){
-        if(junctions_.count(vertex)){
-          Edge edge(vertex,vertex);
-          edges.push_back(edge);
-          break;
-        }
-      }
-     }else{
-      edges.push_back(edge);
-     }
-     }
-    return edges;*/
-  return edge_container_.getEdges();
 }
 
 vector<int> ReducedGraph::getVertices() const {

--- a/src/libtools/reducedgraph.cc
+++ b/src/libtools/reducedgraph.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -105,16 +105,18 @@ ReducedGraph::ReducedGraph(std::vector<ReducedEdge> reduced_edges,
   init_(reduced_edges, nodes);
 }
 
-Graph ReducedGraph::expandGraph(){
+Graph ReducedGraph::expandGraph() {
   vector<Edge> all_expanded_edges;
-  for( const pair<Edge,vector<vector<int>>> edge_and_vertices : expanded_edges_){
+  for (const pair<Edge, vector<vector<int>>> edge_and_vertices :
+       expanded_edges_) {
     vector<vector<Edge>> edges_local = expandEdge(edge_and_vertices.first);
-    for( vector<Edge>& edges : edges_local){
-      all_expanded_edges.insert(all_expanded_edges.end(),edges.begin(),edges.end());
+    for (vector<Edge>& edges : edges_local) {
+      all_expanded_edges.insert(all_expanded_edges.end(), edges.begin(),
+                                edges.end());
     }
   }
   cout << "Number of nodes when calling expandGraph " << nodes_.size() << endl;
-  return Graph(all_expanded_edges,nodes_);
+  return Graph(all_expanded_edges, nodes_);
 }
 
 vector<vector<Edge>> ReducedGraph::expandEdge(Edge edge) {
@@ -132,12 +134,13 @@ vector<vector<Edge>> ReducedGraph::expandEdge(Edge edge) {
   return all_edges;
 }
 
-set<int> getAllConnectedVertices_(const unordered_map<Edge,vector<vector<int>>>& expanded_edges){
+set<int> getAllConnectedVertices_(
+    const unordered_map<Edge, vector<vector<int>>>& expanded_edges) {
   set<int> all_vertices;
 
-  for(const auto& edge_and_chains : expanded_edges){
-    for(vector<int> chain : edge_and_chains.second){
-      all_vertices.insert(chain.begin(),chain.end());
+  for (const auto& edge_and_chains : expanded_edges) {
+    for (vector<int> chain : edge_and_chains.second) {
+      all_vertices.insert(chain.begin(), chain.end());
     }
   }
   return all_vertices;
@@ -152,26 +155,27 @@ vector<pair<int, GraphNode>> ReducedGraph::getNodes() {
 
   set<int> all_connected_vertices = getAllConnectedVertices_(expanded_edges_);
   // Grab the nodes that are not attached to any edges
-  for( pair<int,GraphNode> id_and_node : nodes_){
-    if(!all_connected_vertices.count(id_and_node.first)){
+  for (pair<int, GraphNode> id_and_node : nodes_) {
+    if (!all_connected_vertices.count(id_and_node.first)) {
       nodes.push_back(id_and_node);
     }
   }
-  cout << "Number of nodes calling getNodes from reduced graph " << nodes.size() << endl;
+  cout << "Number of nodes calling getNodes from reduced graph " << nodes.size()
+       << endl;
   return nodes;
 }
 
-vector<int> ReducedGraph::getVerticesDegree(int degree) const{
-  if(degree==0){
+vector<int> ReducedGraph::getVerticesDegree(int degree) const {
+  if (degree == 0) {
     set<int> all_connected_vertices = getAllConnectedVertices_(expanded_edges_);
     vector<int> vertices;
-    for(const pair<int,GraphNode> id_and_node : nodes_){
-      if(all_connected_vertices.count(id_and_node.first)==false){
+    for (const pair<int, GraphNode> id_and_node : nodes_) {
+      if (all_connected_vertices.count(id_and_node.first) == false) {
         vertices.push_back(id_and_node.first);
       }
       return vertices;
     }
-  }else{
+  } else {
     return edge_container_.getVerticesDegree(degree);
   }
 }

--- a/src/libtools/reducedgraph.cc
+++ b/src/libtools/reducedgraph.cc
@@ -64,6 +64,7 @@ void ReducedGraph::init_(vector<ReducedEdge> reduced_edges,
     }
   }
   edge_container_ = EdgeContainer(edges);
+
   calcId_();
 }
 
@@ -91,6 +92,7 @@ ReducedGraph::ReducedGraph(std::vector<ReducedEdge> reduced_edges) {
 
 ReducedGraph::ReducedGraph(std::vector<ReducedEdge> reduced_edges,
                            unordered_map<int, GraphNode> nodes) {
+
   set<int> vertices = getAllVertices_(reduced_edges);
   if (nodes.size() < vertices.size()) {
     throw invalid_argument(
@@ -103,6 +105,13 @@ ReducedGraph::ReducedGraph(std::vector<ReducedEdge> reduced_edges,
     }
   }
   init_(reduced_edges, nodes);
+
+  // Add all the nodes that are isolated
+  for (pair<const int, GraphNode>& id_and_node : nodes) {
+    if (vertices.count(id_and_node.first) == 0) {
+      edge_container_.addVertex(id_and_node.first);
+    }
+  }
 }
 
 Graph ReducedGraph::expandGraph() {
@@ -159,6 +168,12 @@ vector<pair<int, GraphNode>> ReducedGraph::getNodes() const {
     }
   }
   return nodes;
+}
+
+vector<int> ReducedGraph::getVertices() const {
+  // Get all the vertices that are in the reduced graph
+  vector<int> vertices = edge_container_.getVertices();
+  return vertices;
 }
 
 vector<int> ReducedGraph::getVerticesDegree(int degree) const {

--- a/src/libtools/reducedgraph.cc
+++ b/src/libtools/reducedgraph.cc
@@ -29,6 +29,10 @@ namespace tools {
 
 class GraphNode;
 
+/******************************************************************************
+ * Internal Private Functions
+ ******************************************************************************/
+
 /**
  * \brief Function will compare a chain with a vector of chains
  *
@@ -226,6 +230,32 @@ bool reorderAndStoreChainIfDoesNotExist_(
   return false;
 }
 
+set<int> getAllVertices_(const std::vector<ReducedEdge>& reduced_edges) {
+  set<int> vertices;
+  for (const ReducedEdge& reduced_edge : reduced_edges) {
+    vector<int> chain = reduced_edge.getChain();
+    for (const int vertex : chain) {
+      vertices.insert(vertex);
+    }
+  }
+  return vertices;
+}
+
+set<int> getAllConnectedVertices_(
+    const unordered_map<Edge, vector<vector<int>>>& expanded_edges) {
+  set<int> all_vertices;
+
+  for (const auto& edge_and_chains : expanded_edges) {
+    for (vector<int> chain : edge_and_chains.second) {
+      all_vertices.insert(chain.begin(), chain.end());
+    }
+  }
+  return all_vertices;
+}
+/******************************************************************************
+ * Private Class Methods
+ ******************************************************************************/
+
 void ReducedGraph::init_(vector<ReducedEdge> reduced_edges,
                          unordered_map<int, GraphNode> nodes) {
   vector<Edge> edges;
@@ -261,16 +291,9 @@ void ReducedGraph::init_(vector<ReducedEdge> reduced_edges,
   calcId_();
 }
 
-set<int> getAllVertices_(const std::vector<ReducedEdge>& reduced_edges) {
-  set<int> vertices;
-  for (const ReducedEdge& reduced_edge : reduced_edges) {
-    vector<int> chain = reduced_edge.getChain();
-    for (const int vertex : chain) {
-      vertices.insert(vertex);
-    }
-  }
-  return vertices;
-}
+/******************************************************************************
+ * Public Class Methods
+ ******************************************************************************/
 
 ReducedGraph::ReducedGraph(std::vector<ReducedEdge> reduced_edges) {
 
@@ -307,7 +330,7 @@ ReducedGraph::ReducedGraph(std::vector<ReducedEdge> reduced_edges,
   }
 }
 
-Graph ReducedGraph::expandGraph() {
+Graph ReducedGraph::expandGraph() const {
   vector<Edge> all_expanded_edges;
   for (const pair<Edge, vector<vector<int>>> edge_and_vertices :
        expanded_edges_) {
@@ -334,17 +357,6 @@ vector<vector<Edge>> ReducedGraph::expandEdge(const Edge& edge) const {
   return all_edges;
 }
 
-set<int> getAllConnectedVertices_(
-    const unordered_map<Edge, vector<vector<int>>>& expanded_edges) {
-  set<int> all_vertices;
-
-  for (const auto& edge_and_chains : expanded_edges) {
-    for (vector<int> chain : edge_and_chains.second) {
-      all_vertices.insert(chain.begin(), chain.end());
-    }
-  }
-  return all_vertices;
-}
 vector<pair<int, GraphNode>> ReducedGraph::getNodes() const {
   vector<int> vertices = edge_container_.getVertices();
   vector<pair<int, GraphNode>> nodes;
@@ -361,12 +373,6 @@ vector<pair<int, GraphNode>> ReducedGraph::getNodes() const {
     }
   }
   return nodes;
-}
-
-vector<int> ReducedGraph::getVertices() const {
-  // Get all the vertices that are in the reduced graph
-  vector<int> vertices = edge_container_.getVertices();
-  return vertices;
 }
 
 vector<int> ReducedGraph::getVerticesDegree(int degree) const {

--- a/src/libtools/reducedgraph.cc
+++ b/src/libtools/reducedgraph.cc
@@ -69,7 +69,7 @@ void ReducedGraph::init_(vector<ReducedEdge> reduced_edges,
 
 set<int> getAllVertices_(const std::vector<ReducedEdge>& reduced_edges) {
   set<int> vertices;
-  for (auto reduced_edge : reduced_edges) {
+  for (const ReducedEdge& reduced_edge : reduced_edges) {
     vector<int> chain = reduced_edge.getChain();
     for (const int vertex : chain) {
       vertices.insert(vertex);
@@ -118,15 +118,14 @@ Graph ReducedGraph::expandGraph() {
   return Graph(all_expanded_edges, nodes_);
 }
 
-vector<vector<Edge>> ReducedGraph::expandEdge(Edge edge) {
-  assert(expanded_edges_.count(edge));
+vector<vector<Edge>> ReducedGraph::expandEdge(const Edge& edge) const {
   vector<vector<Edge>> all_edges;
-  vector<vector<int>> chains = expanded_edges_[edge];
+  vector<vector<int>> chains = expanded_edges_.at(edge);
   for (vector<int> vertices : chains) {
     vector<Edge> edges;
     for (size_t index = 0; index < (vertices.size() - 1); ++index) {
-      Edge edge(vertices.at(index), vertices.at(index + 1));
-      edges.push_back(edge);
+      Edge edge_temp(vertices.at(index), vertices.at(index + 1));
+      edges.push_back(edge_temp);
     }
     all_edges.push_back(edges);
   }
@@ -144,11 +143,11 @@ set<int> getAllConnectedVertices_(
   }
   return all_vertices;
 }
-vector<pair<int, GraphNode>> ReducedGraph::getNodes() {
+vector<pair<int, GraphNode>> ReducedGraph::getNodes() const {
   vector<int> vertices = edge_container_.getVertices();
   vector<pair<int, GraphNode>> nodes;
   for (const int vertex : vertices) {
-    pair<int, GraphNode> id_and_node(vertex, nodes_[vertex]);
+    pair<int, GraphNode> id_and_node(vertex, nodes_.at(vertex));
     nodes.push_back(id_and_node);
   }
 

--- a/src/libtools/reducedgraph.cc
+++ b/src/libtools/reducedgraph.cc
@@ -318,9 +318,8 @@ vector<int> ReducedGraph::getVerticesDegree(int degree) const {
       }
       return vertices;
     }
-  } else {
-    return edge_container_.getVerticesDegree(degree);
   }
+  return edge_container_.getVerticesDegree(degree);
 }
 
 ostream& operator<<(ostream& os, const ReducedGraph graph) {

--- a/src/libtools/reducedgraph.cc
+++ b/src/libtools/reducedgraph.cc
@@ -115,7 +115,6 @@ Graph ReducedGraph::expandGraph() {
                                 edges.end());
     }
   }
-  cout << "Number of nodes when calling expandGraph " << nodes_.size() << endl;
   return Graph(all_expanded_edges, nodes_);
 }
 
@@ -160,8 +159,6 @@ vector<pair<int, GraphNode>> ReducedGraph::getNodes() {
       nodes.push_back(id_and_node);
     }
   }
-  cout << "Number of nodes calling getNodes from reduced graph " << nodes.size()
-       << endl;
   return nodes;
 }
 

--- a/src/tests/test_edgecontainer.cc
+++ b/src/tests/test_edgecontainer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@
 #include <exception>
 #include <iostream>
 #include <vector>
-#include <votca/tools/edgecontainer.h>
 #include <votca/tools/edge.h>
+#include <votca/tools/edgecontainer.h>
 
 using namespace std;
 using namespace votca::tools;
@@ -38,16 +38,39 @@ BOOST_AUTO_TEST_CASE(create_test) {
   EdgeContainer edCo3(eds);
 }
 
-BOOST_AUTO_TEST_CASE(getdegree_test){
-  Edge ed(1, 2);
-  Edge ed2(2, 3);
-  vector<Edge> eds{ed, ed2};
-  EdgeContainer edCo(eds);
-  BOOST_CHECK(edCo.getDegree(1)==1);
-  BOOST_CHECK(edCo.getDegree(2)==2);
-  BOOST_CHECK(edCo.getDegree(3)==1);
-  BOOST_CHECK_THROW(edCo.getDegree(4),invalid_argument);
-} 
+BOOST_AUTO_TEST_CASE(getdegree_test) {
+  {
+    Edge ed(1, 2);
+    Edge ed2(2, 3);
+    vector<Edge> eds{ed, ed2};
+    EdgeContainer edge_container(eds);
+    BOOST_CHECK(edge_container.getDegree(1) == 1);
+    BOOST_CHECK(edge_container.getDegree(2) == 2);
+    BOOST_CHECK(edge_container.getDegree(3) == 1);
+    BOOST_CHECK_THROW(edge_container.getDegree(4), invalid_argument);
+  }
+
+  {
+    //    _
+    //  /  \      3
+    //  \  /      |
+    //    1 - 4 - 8 - 5
+    //
+    Edge ed1(1, 4);
+    Edge ed2(1, 1);
+    Edge ed3(4, 8);
+    Edge ed4(8, 3);
+    Edge ed5(8, 5);
+    vector<Edge> edges{ed1, ed2, ed3, ed4, ed5};
+    EdgeContainer edge_container(edges);
+
+    BOOST_CHECK_EQUAL(edge_container.getDegree(1), 3);
+    BOOST_CHECK_EQUAL(edge_container.getDegree(4), 2);
+    BOOST_CHECK_EQUAL(edge_container.getDegree(8), 3);
+    BOOST_CHECK_EQUAL(edge_container.getDegree(3), 1);
+    BOOST_CHECK_EQUAL(edge_container.getDegree(5), 1);
+  }
+}
 
 BOOST_AUTO_TEST_CASE(edgeexist_test) {
   Edge ed(1, 2);
@@ -106,12 +129,12 @@ BOOST_AUTO_TEST_CASE(getedges_test) {
   vec_ed = edCo.getEdges();
   int ed_count = 0;
   int ed2_count = 0;
-  for(auto e1 : vec_ed){
-    if(e1==ed) ++ed_count;
-    if(e1==ed2) ++ed2_count;
+  for (auto e1 : vec_ed) {
+    if (e1 == ed) ++ed_count;
+    if (e1 == ed2) ++ed2_count;
   }
-  BOOST_CHECK_EQUAL(ed_count,2);
-  BOOST_CHECK_EQUAL(ed2_count,1);
+  BOOST_CHECK_EQUAL(ed_count, 2);
+  BOOST_CHECK_EQUAL(ed2_count, 1);
 }
 
 BOOST_AUTO_TEST_CASE(getvertices_test) {
@@ -177,47 +200,46 @@ BOOST_AUTO_TEST_CASE(getneighedges) {
   BOOST_CHECK(edge2_found);
 
   // Should be able to add the same edge more than once
-  Edge ed3(3,4);
+  Edge ed3(3, 4);
   edCo.addEdge(ed);
   edCo.addEdge(ed3);
 
   vec_edgs = edCo.getNeighEdges(1);
-  BOOST_CHECK_EQUAL(vec_edgs.size(),2);
-  BOOST_CHECK_EQUAL(vec_edgs.at(0),ed);
-  BOOST_CHECK_EQUAL(vec_edgs.at(1),ed);
+  BOOST_CHECK_EQUAL(vec_edgs.size(), 2);
+  BOOST_CHECK_EQUAL(vec_edgs.at(0), ed);
+  BOOST_CHECK_EQUAL(vec_edgs.at(1), ed);
 
   vec_edgs = edCo.getNeighEdges(2);
-  BOOST_CHECK_EQUAL(vec_edgs.size(),3);
+  BOOST_CHECK_EQUAL(vec_edgs.size(), 3);
 
   int edge_count = 0;
   int edge_count2 = 0;
-  for(auto e1 : vec_edgs){
-    if(e1 == ed ) ++edge_count;
-    if(e1 == ed2 ) ++edge_count2;
+  for (auto e1 : vec_edgs) {
+    if (e1 == ed) ++edge_count;
+    if (e1 == ed2) ++edge_count2;
   }
-  BOOST_CHECK_EQUAL(edge_count,2);
-  BOOST_CHECK_EQUAL(edge_count2,1);
-  
+  BOOST_CHECK_EQUAL(edge_count, 2);
+  BOOST_CHECK_EQUAL(edge_count2, 1);
 }
 
 BOOST_AUTO_TEST_CASE(getmaxdegree) {
-  Edge ed(1,2);
-  Edge ed1(2,3);
-  Edge ed2(2,4);
-  Edge ed3(3,5);
-  
+  Edge ed(1, 2);
+  Edge ed1(2, 3);
+  Edge ed2(2, 4);
+  Edge ed3(3, 5);
+
   EdgeContainer edCo;
   edCo.addEdge(ed);
   edCo.addEdge(ed1);
   edCo.addEdge(ed2);
   edCo.addEdge(ed3);
-  
+
   int maxD = edCo.getMaxDegree();
-  BOOST_CHECK_EQUAL(maxD,3);
+  BOOST_CHECK_EQUAL(maxD, 3);
 
   edCo.addEdge(ed);
   maxD = edCo.getMaxDegree();
-  BOOST_CHECK_EQUAL(maxD,4);
+  BOOST_CHECK_EQUAL(maxD, 4);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_graph_base.cc
+++ b/src/tests/test_graph_base.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 #include <cmath>
 #include <exception>
 #include <iostream>
-#include <iostream>
 #include <votca/tools/edge.h>
 #include <votca/tools/graph.h>
 #include <votca/tools/graphnode.h>
@@ -41,11 +40,11 @@ BOOST_AUTO_TEST_SUITE(graph_test)
 
 BOOST_AUTO_TEST_CASE(constructors_test) { Graph g; }
 
-/** 
+/**
  * \brief Test on isolated nodes method
  *
  * The isolated nodes method is meant to grab any nodes that have no edges, as
- * in they exist as islands within the context of the graph. 
+ * in they exist as islands within the context of the graph.
  */
 BOOST_AUTO_TEST_CASE(isolatednodes_test) {
 
@@ -66,7 +65,7 @@ BOOST_AUTO_TEST_CASE(isolatednodes_test) {
 
     /// In this test case gn, gn1 and gn2 are all islands no edges have been
     /// specified to connect them. Calling getIsolatedNodes() thus returns all
-    /// three of them. 
+    /// three of them.
     vector<Edge> vec_ed;
     GraphNode gn;
     GraphNode gn1;
@@ -129,7 +128,7 @@ BOOST_AUTO_TEST_CASE(isolatednodes_test) {
     BOOST_CHECK(node2);
   }
 
-  /// In this test the junctions of the graph are returned, the junctions 
+  /// In this test the junctions of the graph are returned, the junctions
   /// consist of vertices of three or more connections
   {
 
@@ -147,12 +146,12 @@ BOOST_AUTO_TEST_CASE(isolatednodes_test) {
     m_gn[2] = gn2;
 
     Graph g(vec_ed, m_gn);
-    auto junctions = g.getJunctions();  
+    auto junctions = g.getJunctions();
 
     BOOST_CHECK(!junctions.size());
   }
 
-  /// In this test the junctions of the graph are returned, the junctions 
+  /// In this test the junctions of the graph are returned, the junctions
   /// consist of vertices of three or more connections
   {
 
@@ -160,7 +159,7 @@ BOOST_AUTO_TEST_CASE(isolatednodes_test) {
     Edge ed(0, 2);
     Edge ed2(1, 2);
     Edge ed3(3, 2);
-    vector<Edge> vec_ed{ ed, ed2, ed3};
+    vector<Edge> vec_ed{ed, ed2, ed3};
 
     GraphNode gn;
     GraphNode gn1;
@@ -174,46 +173,10 @@ BOOST_AUTO_TEST_CASE(isolatednodes_test) {
     m_gn[3] = gn3;
 
     Graph g(vec_ed, m_gn);
-    auto junctions = g.getJunctions();  
+    auto junctions = g.getJunctions();
 
-    BOOST_CHECK_EQUAL(junctions.size(),1);
-    BOOST_CHECK_EQUAL(junctions.at(0),2);
-  }
-}
-
-/** 
- * \brief Determine which vertices are missing a ndoe object
- *
- * The graph class used here is composed of vertices, edges and nodes. The node
- * objects contain information about the vertex. When the graph is created both
- * the edges and nodes are passed as arguments. It may happen that an edge 
- * refers to a vertex that does not contain a corresponding graph object, this 
- * method will determine which vertices have no graph object associated with 
- * them.
- */
-BOOST_AUTO_TEST_CASE(verticesmissingnodes_test) {
-  {
-
-    /// Here we have created an edge that corresponds to vertex 0 and 1
-    vector<Edge> vec_ed;
-    Edge ed(0, 1);
-    vec_ed.push_back(ed);
-
-    GraphNode gn;
-    GraphNode gn2;
-    GraphNode gn3;
-
-    /// Notice there is no node with id 1 though there is an
-    /// edge that refers to vertex 1
-    unordered_map<int, GraphNode> m_gn;
-    m_gn[0] = gn;
-    m_gn[2] = gn2;
-    m_gn[3] = gn3;
-
-    Graph g(vec_ed, m_gn);
-    /// A call to getVerticesMissingNodes should return vertex 1
-    auto missing_nd = g.getVerticesMissingNodes();
-    BOOST_CHECK_EQUAL(missing_nd.at(0), 1);
+    BOOST_CHECK_EQUAL(junctions.size(), 1);
+    BOOST_CHECK_EQUAL(junctions.at(0), 2);
   }
 }
 
@@ -259,8 +222,8 @@ BOOST_AUTO_TEST_CASE(junctions_test) {
   Graph g(vec_ed, m_gn);
   // A junction should consist of a vertex with degree of 3 or more
   auto junctions = g.getJunctions();
-  BOOST_CHECK(junctions.size()==1);
-  BOOST_CHECK_EQUAL(junctions.at(0),2);
+  BOOST_CHECK(junctions.size() == 1);
+  BOOST_CHECK_EQUAL(junctions.at(0), 2);
 }
 
 BOOST_AUTO_TEST_CASE(get_edges_test) {
@@ -309,11 +272,11 @@ BOOST_AUTO_TEST_CASE(get_edges_test) {
   bool ed1_found = false;
   bool ed2_found = false;
   bool ed3_found = false;
-  for(auto ed_temp : edges){
-    if(ed_temp==ed) ed0_found = true;
-    if(ed_temp==ed1) ed1_found = true;
-    if(ed_temp==ed2) ed2_found = true;
-    if(ed_temp==ed3) ed3_found = true;
+  for (auto ed_temp : edges) {
+    if (ed_temp == ed) ed0_found = true;
+    if (ed_temp == ed1) ed1_found = true;
+    if (ed_temp == ed2) ed2_found = true;
+    if (ed_temp == ed3) ed3_found = true;
   }
 
   BOOST_CHECK(ed0_found);
@@ -364,16 +327,16 @@ BOOST_AUTO_TEST_CASE(get_vertices_test) {
   Graph g(vec_ed, m_gn);
   auto vertices = g.getVertices();
 
-  vector<bool> vertices_found(5,false);
-  for( auto vertex : vertices){
-    if(vertex==0) vertices_found.at(0)=true;
-    if(vertex==1) vertices_found.at(1)=true;
-    if(vertex==2) vertices_found.at(2)=true;
-    if(vertex==3) vertices_found.at(3)=true;
-    if(vertex==4) vertices_found.at(4)=true;
+  vector<bool> vertices_found(5, false);
+  for (auto vertex : vertices) {
+    if (vertex == 0) vertices_found.at(0) = true;
+    if (vertex == 1) vertices_found.at(1) = true;
+    if (vertex == 2) vertices_found.at(2) = true;
+    if (vertex == 3) vertices_found.at(3) = true;
+    if (vertex == 4) vertices_found.at(4) = true;
   }
 
-  for( auto found : vertices_found){
+  for (auto found : vertices_found) {
     BOOST_CHECK(found);
   }
 }
@@ -523,54 +486,52 @@ BOOST_AUTO_TEST_CASE(neighbornode_test) {
   Graph g(vec_ed, m_gn);
 
   auto neigh1 = g.getNeighNodes(0);
-  BOOST_CHECK_EQUAL(neigh1.size(),1);
-  bool neigh1_found1 = neigh1.at(0).second==gn1;
+  BOOST_CHECK_EQUAL(neigh1.size(), 1);
+  bool neigh1_found1 = neigh1.at(0).second == gn1;
   BOOST_CHECK(neigh1_found1);
-  
+
   auto neigh2 = g.getNeighNodes(1);
-  BOOST_CHECK_EQUAL(neigh2.size(),2);
+  BOOST_CHECK_EQUAL(neigh2.size(), 2);
   bool neigh2_found1 = false;
   bool neigh2_found2 = false;
-  for(auto neigh_pr : neigh2){
-    if(neigh_pr.second==gn4) neigh2_found1=true;
-    if(neigh_pr.second==gn3) neigh2_found2=true;
+  for (auto neigh_pr : neigh2) {
+    if (neigh_pr.second == gn4) neigh2_found1 = true;
+    if (neigh_pr.second == gn3) neigh2_found2 = true;
   }
   BOOST_CHECK(neigh2_found1);
   BOOST_CHECK(neigh2_found2);
 
   auto neigh3 = g.getNeighNodes(2);
-  BOOST_CHECK_EQUAL(neigh3.size(),3);
+  BOOST_CHECK_EQUAL(neigh3.size(), 3);
   bool neigh3_found1 = false;
   bool neigh3_found2 = false;
   bool neigh3_found3 = false;
-  for(auto neigh_pr : neigh3){
-    if(neigh_pr.second==gn1) neigh3_found1=true;
-    if(neigh_pr.second==gn2) neigh3_found2=true;
-    if(neigh_pr.second==gn) neigh3_found3=true;
+  for (auto neigh_pr : neigh3) {
+    if (neigh_pr.second == gn1) neigh3_found1 = true;
+    if (neigh_pr.second == gn2) neigh3_found2 = true;
+    if (neigh_pr.second == gn) neigh3_found3 = true;
   }
   BOOST_CHECK(neigh3_found1);
   BOOST_CHECK(neigh3_found2);
   BOOST_CHECK(neigh3_found3);
 
   auto neigh4 = g.getNeighNodes(3);
-  BOOST_CHECK_EQUAL(neigh4.size(),1);
-  bool neigh4_found1 = neigh4.at(0).second==gn3;
+  BOOST_CHECK_EQUAL(neigh4.size(), 1);
+  bool neigh4_found1 = neigh4.at(0).second == gn3;
   BOOST_CHECK(neigh4_found1);
 
   auto neigh5 = g.getNeighNodes(4);
-  BOOST_CHECK_EQUAL(neigh5.size(),1);
-  bool neigh5_found1 = neigh5.at(0).second==gn3;
+  BOOST_CHECK_EQUAL(neigh5.size(), 1);
+  bool neigh5_found1 = neigh5.at(0).second == gn3;
   BOOST_CHECK(neigh5_found1);
-
 }
 
-
 /**
- * \brief Equivalence test 
+ * \brief Equivalence test
  *
  * Here we demonstrate how the equivalence test works it is purely dependendent
- * on whether the contents of the graphnodes in the graph contain the same 
- * information. 
+ * on whether the contents of the graphnodes in the graph contain the same
+ * information.
  */
 BOOST_AUTO_TEST_CASE(id_test) {
   {

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -263,8 +263,6 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     BOOST_CHECK_EQUAL(edge_count1_2, 3);
   }
 
-=======
->>>>>>> feature-explore-branch-algorithm
   {
     // Create edge
     //     2

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -20,6 +20,7 @@
 #define BOOST_TEST_MAIN
 
 #define BOOST_TEST_MODULE graphalgorithm_test
+
 #include <boost/test/unit_test.hpp>
 #include <memory>
 #include <unordered_map>

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     vector<Edge> edges2 = reduced_g.getEdges();
     BOOST_CHECK_EQUAL(edges2.size(), 3);
 
-    int edge_count1_2;
+    int edge_count1_2=0;
     for (const Edge& edge_temp : edges2) {
       if (edge_temp == ed1) ++edge_count1_2;
     }

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -199,6 +199,7 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     ReducedGraph reduced_graph = reduceGraph(graph);
 
     vector<Edge> edges2 = reduced_graph.getEdges();
+
     BOOST_CHECK_EQUAL(edges2.size(), 1);
 
     Edge ed_check(1, 1);
@@ -220,6 +221,116 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     for (bool found : found_edge) {
       BOOST_CHECK(found);
     }
+  }
+
+  {
+    // Test that the reduced graph handles loop and edge correctly
+    //
+    // 1 - 2
+    // |   |
+    // 4 - 3 - 5 - 6
+    //
+    // Should reduce this to
+    //
+    // 3 - 3
+    // 3 - 6
+    //
+    vector<Edge> edges{Edge(1, 2), Edge(2, 3), Edge(3, 4),
+                       Edge(1, 4), Edge(3, 5), Edge(5, 6)};
+
+    unordered_map<int, GraphNode> nodes;
+    for (int vertex = 1; vertex <= 6; ++vertex) {
+      GraphNode gn;
+      nodes[vertex] = gn;
+    }
+
+    Graph graph(edges, nodes);
+    ReducedGraph reduced_graph = reduceGraph(graph);
+
+    vector<Edge> edges2 = reduced_graph.getEdges();
+    BOOST_CHECK_EQUAL(edges2.size(), 2);
+
+    cout << "EDGE CHECK **************************************" << endl;
+
+    Edge ed3_3(3, 3);
+    Edge ed3_6(3, 6);
+
+    bool found_edge3_3 = false;
+    bool found_edge3_6 = false;
+    for (Edge ed : edges2) {
+      if (ed == ed3_3) {
+        found_edge3_3 = true;
+      } else if (ed == ed3_6) {
+        found_edge3_6 = true;
+      }
+    }
+    BOOST_CHECK(found_edge3_3);
+    BOOST_CHECK(found_edge3_6);
+  }
+
+  {
+    // Test that the reduced graph handles loop and edge correctly
+    //
+    // 1 - 2       6 - 8
+    // |   |       |   |
+    // 4 - 3 - 5 - 7 - 9
+    //
+    // Should reduce this to
+    //
+    // 3 - 3
+    // 3 - 7
+    // 7 - 7
+    //
+    vector<Edge> edges{Edge(1, 2), Edge(2, 3), Edge(3, 4), Edge(1, 4),
+                       Edge(3, 5), Edge(5, 7), Edge(7, 6), Edge(6, 8),
+                       Edge(8, 9), Edge(9, 7)};
+
+    unordered_map<int, GraphNode> nodes;
+    for (int vertex = 1; vertex <= 9; ++vertex) {
+      GraphNode gn;
+      nodes[vertex] = gn;
+    }
+
+    Graph graph(edges, nodes);
+    ReducedGraph reduced_graph = reduceGraph(graph);
+
+    vector<int> junctions = reduced_graph.getJunctions();
+    BOOST_CHECK_EQUAL(junctions.size(), 2);
+    bool found_junction_3 = false;
+    bool found_junction_7 = false;
+    for (int junction : junctions) {
+      if (junction == 3) {
+        found_junction_3 = true;
+      } else if (junction == 7) {
+        found_junction_7 = true;
+      }
+    }
+    BOOST_CHECK(found_junction_3);
+    BOOST_CHECK(found_junction_7);
+
+    vector<Edge> edges2 = reduced_graph.getEdges();
+    BOOST_CHECK_EQUAL(edges2.size(), 3);
+
+    Edge ed3_3(3, 3);
+    Edge ed3_7(3, 7);
+    Edge ed7_7(7, 7);
+
+    bool found_edge3_3 = false;
+    bool found_edge3_7 = false;
+    bool found_edge7_7 = false;
+
+    for (Edge ed : edges2) {
+      if (ed == ed3_3) {
+        found_edge3_3 = true;
+      } else if (ed == ed3_7) {
+        found_edge3_7 = true;
+      } else if (ed == ed7_7) {
+        found_edge7_7 = true;
+      }
+    }
+    BOOST_CHECK(found_edge3_3);
+    BOOST_CHECK(found_edge3_7);
+    BOOST_CHECK(found_edge7_7);
   }
 
   {
@@ -246,6 +357,20 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
 
     Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
+
+    vector<int> junctions = reduced_g.getJunctions();
+    BOOST_CHECK_EQUAL(junctions.size(), 2);
+    bool found_junction_1 = false;
+    bool found_junction_2 = false;
+    for (int junction : junctions) {
+      if (junction == 1) {
+        found_junction_1 = true;
+      } else if (junction == 2) {
+        found_junction_2 = true;
+      }
+    }
+    BOOST_CHECK(found_junction_1);
+    BOOST_CHECK(found_junction_2);
 
     // Should end up with
     //
@@ -313,6 +438,20 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
 
+    vector<int> junctions = reduced_g.getJunctions();
+    BOOST_CHECK_EQUAL(junctions.size(), 2);
+
+    bool found_junction_1 = false;
+    bool found_junction_6 = false;
+    for (int junction : junctions) {
+      if (junction == 1) {
+        found_junction_1 = true;
+      } else if (junction == 6) {
+        found_junction_6 = true;
+      }
+    }
+    BOOST_CHECK(found_junction_1);
+    BOOST_CHECK(found_junction_6);
     // Full Graph
     //
     //     2
@@ -360,6 +499,7 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     int edge_count14_14 = 0;
 
     vector<Edge> edges2 = reduced_g.getEdges();
+
     BOOST_CHECK_EQUAL(edges2.size(), 7);
 
     for (Edge& edge : edges2) {

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -25,11 +25,11 @@
 #include <unordered_map>
 #include <vector>
 #include <votca/tools/graph.h>
-#include <votca/tools/reducedgraph.h>
 #include <votca/tools/graph_bf_visitor.h>
 #include <votca/tools/graphalgorithm.h>
 #include <votca/tools/graphdistvisitor.h>
 #include <votca/tools/graphnode.h>
+#include <votca/tools/reducedgraph.h>
 
 using namespace std;
 using namespace votca::tools;
@@ -38,7 +38,6 @@ using namespace boost;
 using namespace boost::unit_test;
 
 BOOST_AUTO_TEST_SUITE(graphalgorithm_test)
-
 
 BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
   {
@@ -64,7 +63,7 @@ BOOST_AUTO_TEST_CASE(single_network_algorithm_test) {
     Graph_BF_Visitor gb_v;
 
     BOOST_CHECK(gb_v.queEmpty());
-    //gb_v.exec(g,ed);
+    // gb_v.exec(g,ed);
     BOOST_CHECK_THROW(gb_v.exec(g, ed), runtime_error);
 
     bool single_n = singleNetwork(g, gb_v);
@@ -157,21 +156,21 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     nodes[5] = gn6;
     nodes[6] = gn7;
 
-    Graph g(edges,nodes);
+    Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
 
     auto edges2 = reduced_g.getEdges();
-    BOOST_CHECK_EQUAL(edges2.size(),5);
-    vector<bool> found_edges(5,false);
-    for(auto edge : edges2 ){
-      if(edge==ed1) found_edges.at(0) = true;
-      if(edge==ed2) found_edges.at(1) = true;
-      if(edge==ed3) found_edges.at(2) = true;
-      if(edge==ed4) found_edges.at(3) = true;
-      if(edge==ed5) found_edges.at(4) = true;
+    BOOST_CHECK_EQUAL(edges2.size(), 5);
+    vector<bool> found_edges(5, false);
+    for (auto edge : edges2) {
+      if (edge == ed1) found_edges.at(0) = true;
+      if (edge == ed2) found_edges.at(1) = true;
+      if (edge == ed3) found_edges.at(2) = true;
+      if (edge == ed4) found_edges.at(3) = true;
+      if (edge == ed5) found_edges.at(4) = true;
     }
 
-    for(auto found : found_edges){
+    for (auto found : found_edges) {
       BOOST_CHECK(found);
     }
   }
@@ -179,45 +178,45 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
   {
     // Test that the reduced graph handles loops correctly
     //
-    // 1 - 2 
+    // 1 - 2
     // |   |
     // 4 - 3
     //
-    // Should reduce this to 
+    // Should reduce this to
     //
     // 1 - 1
     //
-    vector<Edge> edges{ Edge(1,2), Edge(2,3), Edge(3,4),Edge(1,4)};
+    vector<Edge> edges{Edge(1, 2), Edge(2, 3), Edge(3, 4), Edge(1, 4)};
 
     unordered_map<int, GraphNode> nodes;
-    for(int vertex = 1; vertex<=4;++vertex){
+    for (int vertex = 1; vertex <= 4; ++vertex) {
       GraphNode gn;
       nodes[vertex] = gn;
-    } 
-    
-    Graph graph(edges,nodes);
-    ReducedGraph reduced_graph = reduceGraph(graph);
-  
-    vector<Edge> edges2 = reduced_graph.getEdges();
-    BOOST_CHECK_EQUAL(edges2.size(),1);
-
-    Edge ed_check(1,1);
-    BOOST_CHECK_EQUAL(edges2.at(0),ed_check);
-
-    vector<vector<Edge>> edges3 = reduced_graph.expandEdge(ed_check);
-    BOOST_CHECK_EQUAL(edges3.size(),1);
-    BOOST_CHECK_EQUAL(edges3.at(0).size(),4);
-
-    vector<bool> found_edge(4,false);
-   
-    for(auto edge : edges3.at(0)){
-      if(edge==edges.at(0)) found_edge.at(0) = true;
-      if(edge==edges.at(1)) found_edge.at(1) = true;
-      if(edge==edges.at(2)) found_edge.at(2) = true;
-      if(edge==edges.at(3)) found_edge.at(3) = true;
     }
 
-    for(bool found : found_edge){
+    Graph graph(edges, nodes);
+    ReducedGraph reduced_graph = reduceGraph(graph);
+
+    vector<Edge> edges2 = reduced_graph.getEdges();
+    BOOST_CHECK_EQUAL(edges2.size(), 1);
+
+    Edge ed_check(1, 1);
+    BOOST_CHECK_EQUAL(edges2.at(0), ed_check);
+
+    vector<vector<Edge>> edges3 = reduced_graph.expandEdge(ed_check);
+    BOOST_CHECK_EQUAL(edges3.size(), 1);
+    BOOST_CHECK_EQUAL(edges3.at(0).size(), 4);
+
+    vector<bool> found_edge(4, false);
+
+    for (auto edge : edges3.at(0)) {
+      if (edge == edges.at(0)) found_edge.at(0) = true;
+      if (edge == edges.at(1)) found_edge.at(1) = true;
+      if (edge == edges.at(2)) found_edge.at(2) = true;
+      if (edge == edges.at(3)) found_edge.at(3) = true;
+    }
+
+    for (bool found : found_edge) {
       BOOST_CHECK(found);
     }
   }
@@ -229,22 +228,22 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     // 1 - 2
     //  \  |
     //    3
-    Edge ed1(1,2);
-    Edge ed2(1,4);
-    Edge ed3(1,3);
-    Edge ed4(4,5);
-    Edge ed5(2,5);
-    Edge ed6(2,3);
+    Edge ed1(1, 2);
+    Edge ed2(1, 4);
+    Edge ed3(1, 3);
+    Edge ed4(4, 5);
+    Edge ed5(2, 5);
+    Edge ed6(2, 3);
 
-    vector<Edge> edges{ ed1, ed2, ed3, ed4, ed5, ed6};
+    vector<Edge> edges{ed1, ed2, ed3, ed4, ed5, ed6};
 
     unordered_map<int, GraphNode> nodes;
-    for(int index = 0; index<18;++index){
+    for (int index = 0; index < 18; ++index) {
       GraphNode gn;
       nodes[index] = gn;
     }
 
-    Graph g(edges,nodes);
+    Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
 
     // Should end up with
@@ -252,17 +251,16 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     //  / \
     // 1 - 2
     //  \ /
-    //    
+    //
 
-    
     vector<Edge> edges2 = reduced_g.getEdges();
-    BOOST_CHECK_EQUAL(edges2.size(),3);
+    BOOST_CHECK_EQUAL(edges2.size(), 3);
 
     int edge_count1_2;
-    for(const Edge& edge_temp : edges2){
-      if(edge_temp==ed1) ++edge_count1_2;
+    for (const Edge& edge_temp : edges2) {
+      if (edge_temp == ed1) ++edge_count1_2;
     }
-    BOOST_CHECK_EQUAL(edge_count1_2,3);
+    BOOST_CHECK_EQUAL(edge_count1_2, 3);
   }
 
   {
@@ -285,36 +283,36 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     Edge ed10(3, 9);
 
     //
-    // 10 - 11 - 12 
+    // 10 - 11 - 12
     //
     // 13
     //
-    // 14 - 15 
+    // 14 - 15
     // |    |
     // 16 - 17
     //
     Edge ed11(10, 11);
     Edge ed12(11, 12);
 
-    Edge ed13(14,15);
-    Edge ed14(15,17);
-    Edge ed15(16,17);
-    Edge ed16(14,16);
+    Edge ed13(14, 15);
+    Edge ed14(15, 17);
+    Edge ed15(16, 17);
+    Edge ed16(14, 16);
 
-    vector<Edge> edges{ ed1, ed2, ed3, ed4, ed5, ed6, ed7, ed8, ed9, ed10,
-      ed11, ed12, ed13, ed14, ed15, ed16};
+    vector<Edge> edges{ed1, ed2,  ed3,  ed4,  ed5,  ed6,  ed7,  ed8,
+                       ed9, ed10, ed11, ed12, ed13, ed14, ed15, ed16};
 
     // Create Graph nodes
     unordered_map<int, GraphNode> nodes;
-    for(int index = 0; index<18;++index){
+    for (int index = 0; index < 18; ++index) {
       GraphNode gn;
       nodes[index] = gn;
     }
 
-    Graph g(edges,nodes);
+    Graph g(edges, nodes);
     ReducedGraph reduced_g = reduceGraph(g);
 
-    // Full Graph 
+    // Full Graph
     //
     //     2
     //     |
@@ -322,11 +320,11 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     //     |       |
     //     4 - 5 - 6 -  7 - 8
     //
-    // 10 - 11 - 12 
+    // 10 - 11 - 12
     //
     // 13
     //
-    // 14 - 15 
+    // 14 - 15
     // |    |
     // 16 - 17
     //
@@ -334,56 +332,54 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     //
     //     2
     //     |
-    // 0 - 1 - 
+    // 0 - 1 -
     //     |   |
     //       - 6 - 8
     //
-    // 10 - 12 
+    // 10 - 12
     //
     // 13
     //
-    // 14 -  
+    // 14 -
     // |  |
-    //  - 
+    //  -
     //
-    Edge ed0_1(0,1);
-    Edge ed1_2(1,2);
-    Edge ed1_6(1,6);
-    Edge ed6_8(6,8);
-    Edge ed10_12(10,12);
-    Edge ed14_14(14,14);
+    Edge ed0_1(0, 1);
+    Edge ed1_2(1, 2);
+    Edge ed1_6(1, 6);
+    Edge ed6_8(6, 8);
+    Edge ed10_12(10, 12);
+    Edge ed14_14(14, 14);
 
-    int edge_count0_1 = 0; 
-    int edge_count1_2 = 0; 
-    int edge_count1_6 = 0; 
-    int edge_count6_8 = 0; 
-    int edge_count10_12 = 0; 
-    int edge_count14_14 = 0; 
+    int edge_count0_1 = 0;
+    int edge_count1_2 = 0;
+    int edge_count1_6 = 0;
+    int edge_count6_8 = 0;
+    int edge_count10_12 = 0;
+    int edge_count14_14 = 0;
 
     auto edges2 = reduced_g.getEdges();
-    BOOST_CHECK_EQUAL(edges2.size(),7);
+    BOOST_CHECK_EQUAL(edges2.size(), 7);
 
-    for(auto edge : edges2 ){
-      if(edge==ed0_1) ++edge_count0_1;
-      if(edge==ed1_2) ++edge_count1_2;
-      if(edge==ed1_6) ++edge_count1_6;
-      if(edge==ed6_8) ++edge_count6_8;
-      if(edge==ed10_12) ++edge_count10_12;
-      if(edge==ed14_14) ++edge_count14_14;
-    } 
+    for (auto edge : edges2) {
+      if (edge == ed0_1) ++edge_count0_1;
+      if (edge == ed1_2) ++edge_count1_2;
+      if (edge == ed1_6) ++edge_count1_6;
+      if (edge == ed6_8) ++edge_count6_8;
+      if (edge == ed10_12) ++edge_count10_12;
+      if (edge == ed14_14) ++edge_count14_14;
+    }
 
-    BOOST_CHECK_EQUAL(edge_count0_1,1);
-    BOOST_CHECK_EQUAL(edge_count1_2,1);
-    BOOST_CHECK_EQUAL(edge_count1_6,2);
-    BOOST_CHECK_EQUAL(edge_count6_8,1);
-    BOOST_CHECK_EQUAL(edge_count10_12,1);
-    BOOST_CHECK_EQUAL(edge_count14_14,1);
-
+    BOOST_CHECK_EQUAL(edge_count0_1, 1);
+    BOOST_CHECK_EQUAL(edge_count1_2, 1);
+    BOOST_CHECK_EQUAL(edge_count1_6, 2);
+    BOOST_CHECK_EQUAL(edge_count6_8, 1);
+    BOOST_CHECK_EQUAL(edge_count10_12, 1);
+    BOOST_CHECK_EQUAL(edge_count14_14, 1);
   }
-
 }
 
-BOOST_AUTO_TEST_CASE(explorebranch_test){
+BOOST_AUTO_TEST_CASE(explorebranch_test) {
   {
     // Create edge
     //     2 - 10
@@ -402,39 +398,39 @@ BOOST_AUTO_TEST_CASE(explorebranch_test){
     Edge ed8(7, 8);
     Edge ed9(6, 9);
     Edge ed10(3, 9);
-    Edge ed11(2,10);
+    Edge ed11(2, 10);
 
-    vector<Edge> edges{ ed1, ed2, ed3, ed4, ed5, ed6, ed7, ed8, ed9, ed10, ed11};
+    vector<Edge> edges{ed1, ed2, ed3, ed4, ed5, ed6, ed7, ed8, ed9, ed10, ed11};
 
     // Create Graph nodes
     unordered_map<int, GraphNode> nodes;
-    for(int index = 0; index<11;++index){
+    for (int index = 0; index < 11; ++index) {
       GraphNode gn;
       nodes[index] = gn;
     }
 
-    Graph g(edges,nodes);
+    Graph g(edges, nodes);
 
     int starting_vertex = 1;
-    set<Edge> branch_edges = exploreBranch(g,starting_vertex,ed3);
+    set<Edge> branch_edges = exploreBranch(g, starting_vertex, ed3);
 
-    BOOST_CHECK_EQUAL(branch_edges.size(),8);
+    BOOST_CHECK_EQUAL(branch_edges.size(), 8);
 
-    vector<bool> found_edges(8,false);
+    vector<bool> found_edges(8, false);
     int index = 0;
-    for (auto ed : branch_edges){
-      if(ed == ed3) found_edges.at(index)=true;
-      if(ed == ed4) found_edges.at(index)=true;
-      if(ed == ed5) found_edges.at(index)=true;
-      if(ed == ed6) found_edges.at(index)=true;
-      if(ed == ed7) found_edges.at(index)=true;
-      if(ed == ed8) found_edges.at(index)=true;
-      if(ed == ed9) found_edges.at(index)=true;
-      if(ed == ed10) found_edges.at(index)=true;
+    for (auto ed : branch_edges) {
+      if (ed == ed3) found_edges.at(index) = true;
+      if (ed == ed4) found_edges.at(index) = true;
+      if (ed == ed5) found_edges.at(index) = true;
+      if (ed == ed6) found_edges.at(index) = true;
+      if (ed == ed7) found_edges.at(index) = true;
+      if (ed == ed8) found_edges.at(index) = true;
+      if (ed == ed9) found_edges.at(index) = true;
+      if (ed == ed10) found_edges.at(index) = true;
       ++index;
     }
 
-    for( auto found : found_edges){
+    for (auto found : found_edges) {
       BOOST_CHECK(found);
     }
   }

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     vector<Edge> edges2 = reduced_g.getEdges();
     BOOST_CHECK_EQUAL(edges2.size(), 3);
 
-    int edge_count1_2=0;
+    int edge_count1_2 = 0;
     for (const Edge& edge_temp : edges2) {
       if (edge_temp == ed1) ++edge_count1_2;
     }

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -222,6 +222,48 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     }
   }
 
+  {
+
+    // 4 - 5
+    // |   |
+    // 1 - 2
+    //  \  |
+    //    3
+    Edge ed1(1,2);
+    Edge ed2(1,4);
+    Edge ed3(1,3);
+    Edge ed4(4,5);
+    Edge ed5(2,5);
+    Edge ed6(2,3);
+
+    vector<Edge> edges{ ed1, ed2, ed3, ed4, ed5, ed6};
+
+    unordered_map<int, GraphNode> nodes;
+    for(int index = 0; index<18;++index){
+      GraphNode gn;
+      nodes[index] = gn;
+    }
+
+    Graph g(edges,nodes);
+    ReducedGraph reduced_g = reduceGraph(g);
+
+    // Should end up with
+    //
+    //  / \
+    // 1 - 2
+    //  \ /
+    //    
+
+    
+    vector<Edge> edges2 = reduced_g.getEdges();
+    BOOST_CHECK_EQUAL(edges2.size(),3);
+
+    int edge_count1_2;
+    for(const Edge& edge_temp : edges2){
+      if(edge_temp==ed1) ++edge_count1_2;
+    }
+    BOOST_CHECK_EQUAL(edge_count1_2,3);
+  }
 
   {
     // Create edge

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -373,10 +373,10 @@ BOOST_AUTO_TEST_CASE(reduceGraph_algorithm_test) {
     BOOST_CHECK(found_junction_2);
 
     // Should end up with
-    //
-    //  / \
+    //  _ _
+    // |   |
     // 1 - 2
-    //  \ /
+    // |_ _|
     //
 
     vector<Edge> edges2 = reduced_g.getEdges();

--- a/src/tests/test_graphvisitor.cc
+++ b/src/tests/test_graphvisitor.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -30,9 +30,17 @@
 using namespace std;
 using namespace votca::tools;
 
+class GraphVisitorTest : public GraphVisitor {
+ private:
+  void addEdges_(const Graph&, int) {
+    throw runtime_error("Undefined method.");
+  }
+  Edge getEdge_(const Graph&) { throw runtime_error("Undefined method."); }
+};
+
 BOOST_AUTO_TEST_SUITE(graphvisitor_test)
 
-BOOST_AUTO_TEST_CASE(constructor_test) { GraphVisitor gv; }
+BOOST_AUTO_TEST_CASE(constructor_test) { GraphVisitorTest gv; }
 
 BOOST_AUTO_TEST_CASE(basic_test) {
   // Create edge
@@ -50,7 +58,7 @@ BOOST_AUTO_TEST_CASE(basic_test) {
 
   Graph g(edges, nodes);
 
-  GraphVisitor gv;
+  GraphVisitorTest gv;
 
   BOOST_CHECK(gv.queEmpty());
 
@@ -61,9 +69,9 @@ BOOST_AUTO_TEST_CASE(basic_test) {
   // Error because no nextEdge function ptr passed in
   BOOST_CHECK_THROW(gv.nextEdge(g), runtime_error);
 
-  BOOST_CHECK_EQUAL(gv.getStartingVertex(),0);
+  BOOST_CHECK_EQUAL(gv.getStartingVertex(), 0);
   gv.setStartingVertex(2);
-  BOOST_CHECK_EQUAL(gv.getStartingVertex(),2);
+  BOOST_CHECK_EQUAL(gv.getStartingVertex(), 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_reducedgraph.cc
+++ b/src/tests/test_reducedgraph.cc
@@ -304,7 +304,10 @@ BOOST_AUTO_TEST_CASE(get_vertices_test) {
   m_gn[4] = gn4;
 
   ReducedGraph g(vec_ed, m_gn);
-  auto vertices = g.getVertices();
+  vector<int> vertices = g.getVertices();
+  for (auto vertex : vertices) {
+    cout << vertex << endl;
+  }
   BOOST_CHECK_EQUAL(vertices.size(), 4);
   vector<bool> vertices_found(4, false);
   for (auto vertex : vertices) {


### PR DESCRIPTION
This branch corrects a bug found in the graph_df_visitor class, it also adds extra functionality to the reducedGraph namely the ability to expand and return the full graph. This pull request should only be merged after https://github.com/votca/tools/pull/95. 