### PR TITLE
Removed use of exception handling from name and identity classes

### DIFF
--- a/include/votca/tools/identity.h
+++ b/include/votca/tools/identity.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,7 +18,7 @@
  */
 #ifndef __VOTCA_TOOLS_IDENTITY_H
 #define __VOTCA_TOOLS_IDENTITY_H
-#include <stdexcept>
+#include <cassert>
 namespace votca {
 namespace tools {
 
@@ -27,9 +27,9 @@ namespace tools {
 
     The identity object is meant to provide functionality for storing the id of
     an object it primariy meant to be used in child classes and provides a more
-    safety than other imlementations.
+    safety than other implementations.
 */
-template<typename T>
+template <typename T>
 class Identity {
  private:
   T id_;
@@ -39,16 +39,19 @@ class Identity {
   /// Constructor
   Identity() : id_set_(false) {}
   /// Constructor that takes initial id
-  Identity(const T &id) : id_(id), id_set_(true) {};
+  Identity(const T &id) : id_(id), id_set_(true){};
   /// Gets the id returns error of the id has not been set
   const T &getId() const {
-    if(!id_set_) throw std::runtime_error("ID not set");
+    assert(id_set_ && "No id has been set, cannot get id");
     return id_;
   }
   /// Set the id
-  void setId(const T & id) { id_set_ = true; id_ = id; }
+  void setId(const T &id) {
+    id_set_ = true;
+    id_ = id;
+  }
 };
-}
-}
+}  // namespace tools
+}  // namespace votca
 
 #endif

--- a/include/votca/tools/name.h
+++ b/include/votca/tools/name.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -20,8 +20,8 @@
 #ifndef _VOTCA_TOOLS_NAME_H
 #define _VOTCA_TOOLS_NAME_H
 
+#include <cassert>
 #include <string>
-#include <stdexcept>
 
 namespace votca {
 namespace tools {
@@ -40,18 +40,18 @@ class Name {
   bool name_set_{false};
 
  public:
-  Name() {};
-  Name(const std::string name) : name_(name), name_set_(true) {};
+  Name(){};
+  Name(const std::string name) : name_(name), name_set_(true){};
   void setName(const std::string &name) {
     name_ = name;
     name_set_ = true;
   }
   const std::string &getName() const {
-    if(!name_set_) throw std::runtime_error("Name not set");
+    assert(name_set_ && "No name has been set, cannot get name.");
     return name_;
   }
 };
-}
-}
+}  // namespace tools
+}  // namespace votca
 
 #endif  // _VOTCA_TOOLS_NAME_H

--- a/src/tests/test_identity.cc
+++ b/src/tests/test_identity.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ BOOST_AUTO_TEST_CASE(constructors_test) {
 
 BOOST_AUTO_TEST_CASE(simple_test) {
   Identity<int> id;
-  BOOST_CHECK_THROW(id.getId(), runtime_error);
   Identity<int> id2(32);
   BOOST_CHECK_EQUAL(id2.getId(), 32);
   id2.setId(34);

--- a/src/tests/test_name.cc
+++ b/src/tests/test_name.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ BOOST_AUTO_TEST_CASE(constructors_test) {
 
 BOOST_AUTO_TEST_CASE(accessors_test) {
   Name nm;
-  BOOST_CHECK_THROW(nm.getName(), runtime_error);
   nm.setName("New Name");
   BOOST_CHECK_EQUAL(nm.getName(), "New Name");
   Name nm2("Name2");


### PR DESCRIPTION
Simply, changed out exception handling for assertions since the classes will not be used by the end user directly. 