### PR TITLE
Add constants

### DIFF
--- a/include/votca/tools/constants.h
+++ b/include/votca/tools/constants.h
@@ -64,13 +64,25 @@ const double ev2kj_per_mol = 96.485;
 }  // namespace conv
 
 namespace topology_constants {
+
+/// Used to indicate that a valid element variable has not been assigned
 const std::string unassigned_element = "unassigned";
+
+/// Used to indicate that a valid bead type variable has not been assigned
 const std::string unassigned_bead_type = "unassigned";
+
+/// Used to indicate that a valid residue type variable has not been assigned
 const std::string unassigned_residue_type = "unassigned";
+
+/// Used to indicate that a valid molecule type variable has not been assigned
 const std::string unassigned_molecule_type = "unassigned";
 
+/// Used to indicate a valid residue id has not been assigned
 const int unassigned_residue_id = -1;
+
+/// Used to indicate a valid molecule id has not been assigned
 const int unassigned_molecule_id = -1;
+
 }  // namespace topology_constants
 }  // namespace tools
 }  // namespace votca

--- a/include/votca/tools/constants.h
+++ b/include/votca/tools/constants.h
@@ -63,6 +63,15 @@ const double ev2kj_per_mol = 96.485;
 
 }  // namespace conv
 
+namespace topology_constants {
+const std::string unassigned_element = "unassigned";
+const std::string unassigned_bead_type = "unassigned";
+const std::string unassigned_residue_type = "unassigned";
+const std::string unassigned_molecule_type = "unassigned";
+
+const int unassigned_residue_id = -1;
+const int unassigned_molecule_id = -1;
+}  // namespace topology_constants
 }  // namespace tools
 }  // namespace votca
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,7 +2,8 @@ find_package(Boost 1.53.0 REQUIRED COMPONENTS unit_test_framework)
 
 # Each test listed in Alphabetical order
 foreach(PROG
-    test_cubicspline
+		test_constants
+		test_cubicspline
     test_datacollection
     test_edge_base
     test_edgecontainer

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,31 +4,31 @@ find_package(Boost 1.53.0 REQUIRED COMPONENTS unit_test_framework)
 foreach(PROG
 		test_constants
 		test_cubicspline
-    test_datacollection
-    test_edge_base
-    test_edgecontainer
-    test_elements
-    test_floatingpointcomparison
-    test_graph_base
-    test_graph_bf_visitor
-    test_graph_df_visitor
-    test_graphalgorithm
-    test_graphdistvisitor
-    test_graphnode
-    test_graphvisitor
-    test_histogramnew
-    test_identity
-    test_linalg
-    test_matrix
-    test_name
-    test_reducededge
-    test_reducedgraph
-    test_table
-    test_thread
-    test_tokenizer
-    test_typeconverter
-    test_vec
-    test_property)
+		test_datacollection
+		test_edge_base
+		test_edgecontainer
+		test_elements
+		test_floatingpointcomparison
+		test_graph_base
+		test_graph_bf_visitor
+		test_graph_df_visitor
+		test_graphalgorithm
+		test_graphdistvisitor
+		test_graphnode
+		test_graphvisitor
+		test_histogramnew
+		test_identity
+		test_linalg
+		test_matrix
+		test_name
+		test_reducededge
+		test_reducedgraph
+		test_table
+		test_thread
+		test_tokenizer
+		test_typeconverter
+		test_vec
+		test_property)
 
   file(GLOB ${PROG}_SOURCES ${PROG}*.cc)
   add_executable(unit_${PROG} ${${PROG}_SOURCES})

--- a/src/tests/test_constants.cc
+++ b/src/tests/test_constants.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE constants_test
+#include <boost/test/unit_test.hpp>
+#include <votca/tools/constants.h>
+
+using namespace votca::tools;
+using namespace votca::tools::conv;
+using namespace votca::tools::topology_constants;
+
+BOOST_AUTO_TEST_SUITE(constants_test)
+
+BOOST_AUTO_TEST_CASE(constants_test1) {
+  BOOST_CHECK_CLOSE(Pi, boost::math::constants::pi<double>(), 5E-5);
+  BOOST_CHECK_CLOSE(rSqrtPi, 1.0 / sqrt(boost::math::constants::pi<double>()),
+                    5E-5);
+  BOOST_CHECK_CLOSE(kB, 8.617332478E-5, 5E-5);
+  BOOST_CHECK_CLOSE(hbar, 6.5821192815E-16, 5E-5);
+  BOOST_CHECK_CLOSE(eps0, 8.85418781762E-12 / 1.602176565E-19, 5E-5);
+  BOOST_CHECK_CLOSE(bohr2nm, 0.052917721092, 5E-5);
+  BOOST_CHECK_CLOSE(nm2bohr, 18.897259886, 5E-5);
+  BOOST_CHECK_CLOSE(ang2bohr, 1.8897259886, 5E-5);
+  BOOST_CHECK_CLOSE(bohr2ang, 1.0 / 1.8897259886, 5E-5);
+  BOOST_CHECK_CLOSE(nm2ang, 10.0, 5E-5);
+  BOOST_CHECK_CLOSE(ang2nm, 0.1, 5E-5);
+  BOOST_CHECK_CLOSE(hrt2ev, 27.21138602, 5E-5);
+  BOOST_CHECK_CLOSE(ev2hrt, 1.0 / 27.21138602, 5E-5);
+  double value = 1 /
+                 (4 * boost::math::constants::pi<double>() * 8.854187817e-12) *
+                 1.602176487e-19;
+  BOOST_CHECK_CLOSE(int2eV, value / 1.000e-9, 5E-5);
+  BOOST_CHECK_CLOSE(int2V_m, value / 1.000e-18, 5E-5);
+  BOOST_CHECK_CLOSE(int2V, value / 1.000e-9, 5E-5);
+  BOOST_CHECK_CLOSE(ev2kj_per_mol, 96.485, 5E-5);
+  BOOST_CHECK_EQUAL(unassigned_element, "unassigned");
+  BOOST_CHECK_EQUAL(unassigned_bead_type, "unassigned");
+  BOOST_CHECK_EQUAL(unassigned_residue_type, "unassigned");
+  BOOST_CHECK_EQUAL(unassigned_molecule_type, "unassigned");
+  BOOST_CHECK_EQUAL(unassigned_residue_id, -1);
+  BOOST_CHECK_EQUAL(unassigned_molecule_id, -1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adding explicit constants for dealing with molecule, residue, element type and ids when they have not been assigned. 