### PR TITLE
Prepended integration to votca_property

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -17,6 +17,6 @@ foreach(PROG votca_property)
 
   if(ENABLE_TESTING)
     add_test(integration_${PROG}Help ${PROG} --help)
-    set_tests_properties(${PROG}Help PROPERTIES LABELS "tools;votca")
+    set_tests_properties(integration_${PROG}Help PROPERTIES LABELS "tools;votca")
   endif(ENABLE_TESTING)
 endforeach(PROG)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(PROG votca_property)
   endif (BUILD_MANPAGES)
 
   if(ENABLE_TESTING)
-    add_test(${PROG}Help ${PROG} --help)
+    add_test(integration_${PROG}Help ${PROG} --help)
     set_tests_properties(${PROG}Help PROPERTIES LABELS "tools;votca")
   endif(ENABLE_TESTING)
 endforeach(PROG)


### PR DESCRIPTION
Doing this will allow us to separate the different tests e.g.

ctest -R unit
ctest -R integration
ctest -R memory