### PR TITLE
cmake: Boost_UNIT_TEST_FRAMEWORK_LIBRARY -> Boost::unit_test_framework

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(PROG
 
   file(GLOB ${PROG}_SOURCES ${PROG}*.cc)
   add_executable(unit_${PROG} ${${PROG}_SOURCES})
-  target_link_libraries(unit_${PROG} votca_tools ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+  target_link_libraries(unit_${PROG} votca_tools Boost::unit_test_framework)
   target_compile_definitions(unit_${PROG} PRIVATE BOOST_TEST_DYN_LINK)
   add_test(unit_${PROG} unit_${PROG})
   # run tests for tools (for coverage) as well


### PR DESCRIPTION
Needs to be done in xtp as well, but https://github.com/votca/xtp/pull/277 include that fix already.