### PR TITLE
verbosity levels

### DIFF
--- a/include/votca/tools/calculator.h
+++ b/include/votca/tools/calculator.h
@@ -51,14 +51,6 @@ class Calculator {
    */
   virtual std::string Identify() = 0;
   /**
-   * \brief reads default options from an XML file in VOTCASHARE
-   *
-   * Help files for calculators are installed in the VOTCASHARE folder
-   * These files also contain default values (default attribute)
-   *
-   */
-  void LoadDefaults();
-  /**
    * \brief Initializes a calculator from an XML file with options
    *
    * Options are passed to a calculator by the Application
@@ -100,63 +92,6 @@ class Calculator {
 
   void AddDefaults(Property &p, const Property &defaults);
 };
-
-inline void Calculator::LoadDefaults() {}
-
-inline void Calculator::UpdateWithDefaults(Property &options,
-                                           std::string package) {
-
-  // copy options from the object supplied by the Application
-  std::string id = Identify();
-  Property options_id = options.get("options." + id);
-
-  // add default values if specified in VOTCASHARE
-  char *votca_share = getenv("VOTCASHARE");
-  if (votca_share == nullptr) {
-    throw std::runtime_error("VOTCASHARE not set, cannot open help files.");
-  }
-  // load the xml description of the calculator (with defaults and test values)
-  std::string xmlFile = std::string(getenv("VOTCASHARE")) + std::string("/") +
-                        package + std::string("/xml/") + id +
-                        std::string(".xml");
-
-  Property defaults_all;
-  defaults_all.LoadFromXML(xmlFile);
-  Property defaults = defaults_all.get("options." + id);
-
-  // if a value not given or a tag not present, provide default values
-  AddDefaults(options_id, defaults);
-
-  // output calculator options
-  std::string indent("          ");
-  Index level = 1;
-  votca::tools::PropertyIOManipulator IndentedText(PropertyIOManipulator::TXT,
-                                                   level, indent);
-  if (tools::globals::verbose) {
-    std::cout << "\n... ... options\n"
-              << IndentedText << options_id << "... ... options\n"
-              << std::flush;
-  }
-}
-
-inline void Calculator::AddDefaults(Property &p, const Property &defaults) {
-
-  for (const Property &prop : defaults) {
-    std::string name = prop.path() + "." + prop.name();
-
-    Property rootp = *p.begin();
-    if (prop.hasAttribute("default")) {
-      if (rootp.exists(name)) {
-        if (rootp.HasChildren()) {
-          rootp.value() = prop.value();
-        }
-      } else {
-        rootp.add(prop.name(), prop.value());
-      }
-    }
-    AddDefaults(p, prop);
-  }
-}
 
 }  // namespace tools
 }  // namespace votca

--- a/include/votca/tools/calculator.h
+++ b/include/votca/tools/calculator.h
@@ -32,7 +32,7 @@ namespace tools {
  *
  * Calculators are grouped in CalculatorFactories and are run by Threads
  * or Applications. Every calculator has a description (an XML file) installed
- * in VOTCASHARE which is used to compile HELP and run TESTSUITE.
+ * in VOTCASHARE which is used to compile HELP.
  * This XML file also contains default values.
  *
  */
@@ -120,9 +120,9 @@ inline void Calculator::UpdateWithDefaults(Property &options,
                         package + std::string("/xml/") + id +
                         std::string(".xml");
 
-  Property defaults, defaults_all;
+  Property defaults_all;
   defaults_all.LoadFromXML(xmlFile);
-  defaults = defaults_all.get("options." + id);
+  Property defaults = defaults_all.get("options." + id);
 
   // if a value not given or a tag not present, provide default values
   AddDefaults(options_id, defaults);

--- a/include/votca/tools/globals.h
+++ b/include/votca/tools/globals.h
@@ -22,6 +22,13 @@
 #include <votca/tools/votca_config.h>
 
 namespace votca {
+
+struct Log {
+  /// be loud and noisy
+  enum Level { error = 0, warning = 1, info = 2, debug = 3 };
+
+  static Level current_level;
+};
 namespace tools {
 
 /**
@@ -31,8 +38,7 @@ namespace tools {
 */
 
 struct globals {
-  /// be loud and noisy
-  static bool verbose;
+
   /// web of the package
   static std::string url;
   /// email address of the developers

--- a/include/votca/tools/globals.h
+++ b/include/votca/tools/globals.h
@@ -28,6 +28,8 @@ struct Log {
   enum Level { error = 0, warning = 1, info = 2, debug = 3 };
 
   static Level current_level;
+
+  static bool verbose() { return current_level > Level::error; }
 };
 namespace tools {
 

--- a/src/libtools/application.cc
+++ b/src/libtools/application.cc
@@ -97,6 +97,8 @@ int Application::Exec(int argc, char **argv) {
     //_continue_execution = true;
     AddProgramOptions()("help,h", "  display this help and exit");
     AddProgramOptions()("verbose,v", "  be loud and noisy");
+    AddProgramOptions()("veryverbose,v1", "  be very loud and noisy");
+    AddProgramOptions()("veryveryverbose,v2", "  be very very loud and noisy");
     AddProgramOptions("Hidden")("man", "  output man-formatted manual pages");
     AddProgramOptions("Hidden")("tex", "  output tex-formatted manual pages");
 
@@ -106,7 +108,13 @@ int Application::Exec(int argc, char **argv) {
                      argv);  // initialize general parameters & read input file
 
     if (_op_vm.count("verbose")) {
-      globals::verbose = true;
+      Log::current_level = Log::warning;
+    }
+    if (_op_vm.count("veryverbose")) {
+      Log::current_level = Log::info;
+    }
+    if (_op_vm.count("veryveryverbose")) {
+      Log::current_level = Log::debug;
     }
 
     if (_op_vm.count("man")) {
@@ -222,7 +230,7 @@ void Application::PrintDescription(std::ostream &out,
     if (atr_it != calculator_options.lastAttribute()) {
       help_string = (*atr_it).second;
     } else {
-      if (tools::globals::verbose) {
+      if (Log::current_level > 0) {
         out << _format % calculator_name % "Undocumented";
       }
       return;
@@ -242,7 +250,7 @@ void Application::PrintDescription(std::ostream &out,
     }
 
   } catch (std::exception &) {
-    if (tools::globals::verbose) {
+    if (Log::current_level > 0) {
       out << _format % calculator_name % "Undocumented";
     }
   }

--- a/src/libtools/application.cc
+++ b/src/libtools/application.cc
@@ -96,9 +96,9 @@ int Application::Exec(int argc, char **argv) {
   try {
     //_continue_execution = true;
     AddProgramOptions()("help,h", "  display this help and exit");
-    AddProgramOptions()("verbose,v", "  be loud and noisy");
-    AddProgramOptions()("veryverbose,v1", "  be very loud and noisy");
-    AddProgramOptions()("veryveryverbose,v2", "  be very very loud and noisy");
+    AddProgramOptions()("verbose", "  be loud and noisy");
+    AddProgramOptions()("verbose1", "  be very loud and noisy");
+    AddProgramOptions()("verbose2,v", "  be extremly loud and noisy");
     AddProgramOptions("Hidden")("man", "  output man-formatted manual pages");
     AddProgramOptions("Hidden")("tex", "  output tex-formatted manual pages");
 
@@ -110,10 +110,12 @@ int Application::Exec(int argc, char **argv) {
     if (_op_vm.count("verbose")) {
       Log::current_level = Log::warning;
     }
-    if (_op_vm.count("veryverbose")) {
+
+    if (_op_vm.count("verbose1")) {
       Log::current_level = Log::info;
     }
-    if (_op_vm.count("veryveryverbose")) {
+
+    if (_op_vm.count("verbose2")) {
       Log::current_level = Log::debug;
     }
 
@@ -172,16 +174,14 @@ boost::program_options::options_description_easy_init
 void Application::ParseCommandLine(int argc, char **argv) {
   namespace po = boost::program_options;
 
-  std::map<string, boost::program_options::options_description>::iterator iter;
-
   // default options should be added to visible (the rest is handled via a map))
   _visible_options.add(_op_desc);
 
   // add all categories to list of available options
-  for (iter = _op_groups.begin(); iter != _op_groups.end(); ++iter) {
-    _op_desc.add(iter->second);
-    if (iter->first != "Hidden") {
-      _visible_options.add(iter->second);
+  for (const auto &pair : _op_groups) {
+    _op_desc.add(pair.second);
+    if (pair.first != "Hidden") {
+      _visible_options.add(pair.second);
     }
   }
 

--- a/src/libtools/calculator.cc
+++ b/src/libtools/calculator.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <votca/tools/calculator.h>
+
+namespace votca {
+namespace tools {
+
+void Calculator::UpdateWithDefaults(Property &options, std::string package) {
+
+  // copy options from the object supplied by the Application
+  std::string id = Identify();
+  Property options_id = options.get("options." + id);
+
+  // add default values if specified in VOTCASHARE
+  char *votca_share = getenv("VOTCASHARE");
+  if (votca_share == nullptr) {
+    throw std::runtime_error("VOTCASHARE not set, cannot open help files.");
+  }
+  // load the xml description of the calculator (with defaults and test values)
+  std::string xmlFile = std::string(getenv("VOTCASHARE")) + std::string("/") +
+                        package + std::string("/xml/") + id +
+                        std::string(".xml");
+
+  Property defaults_all;
+  defaults_all.LoadFromXML(xmlFile);
+  Property defaults = defaults_all.get("options." + id);
+
+  // if a value not given or a tag not present, provide default values
+  AddDefaults(options_id, defaults);
+
+  // output calculator options
+  std::string indent("          ");
+  Index level = 1;
+  votca::tools::PropertyIOManipulator IndentedText(PropertyIOManipulator::TXT,
+                                                   level, indent);
+  if (Log::verbose()) {
+    std::cout << "\n... ... options\n"
+              << IndentedText << options_id << "... ... options\n"
+              << std::flush;
+  }
+}
+
+void Calculator::AddDefaults(Property &p, const Property &defaults) {
+
+  for (const Property &prop : defaults) {
+    std::string name = prop.path() + "." + prop.name();
+
+    Property rootp = *p.begin();
+    if (prop.hasAttribute("default")) {
+      if (rootp.exists(name)) {
+        if (rootp.HasChildren()) {
+          rootp.value() = prop.value();
+        }
+      } else {
+        rootp.add(prop.name(), prop.value());
+      }
+    }
+    AddDefaults(p, prop);
+  }
+}
+
+}  // namespace tools
+}  // namespace votca

--- a/src/libtools/globals.cc
+++ b/src/libtools/globals.cc
@@ -18,9 +18,10 @@
 #include <votca/tools/globals.h>
 
 namespace votca {
+
+Log::Level Log::current_level = Log::info;
 namespace tools {
 
-bool globals::verbose = false;
 std::string globals::url = "http://www.votca.org";
 std::string globals::email = "devs@votca.org";
 


### PR DESCRIPTION
I removed the `bool votca::tools::globals::verbosity` which was a global and replaced it by 
a struct `Log` with an enum `enum Level{error,warning,debug,info}` in the `votca` namespace 
the global variable is `votca::Log::current_level` 

the most used command from before 
`if (votca::tools::globals::verbose)` is now replaced by `if(votca::Log::current_level>0)`

I need opinions if that is okay.

higher logging levels are then activated by specifying `--verbose` `--verbose1` `--verbose2` on the command line. `-v` is short for `--verbose2`. @junghans  is that okay for you?

boost::program options only supports one character short options.