### PR TITLE
promoted operators from the base class to be used in derived class to…

### DIFF
--- a/include/votca/tools/reducededge.h
+++ b/include/votca/tools/reducededge.h
@@ -134,6 +134,13 @@ class ReducedEdge : public Edge {
   bool operator<=(const ReducedEdge& edge) const;
   bool operator>=(const ReducedEdge& edge) const;
 
+  using Edge::operator!=;
+  using Edge::operator==;
+  using Edge::operator<;
+  using Edge::operator>;
+  using Edge::operator<=;
+  using Edge::operator>=;
+
   /// Print the contents of the edge
   friend std::ostream& operator<<(std::ostream& os, const ReducedEdge& edge);
 };


### PR DESCRIPTION
… escape shadowing

@JoshuaSBrown did you intend to be able to compare an Edge against a ReducedEdge, otherwise the whole inheritance part does not make sense. 

for https://github.com/votca/votca/issues/228