### PR TITLE
fix build with non-system fftw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ For more detailed information about the changes see the history of the [reposito
 
 ## Version 1.6.1 (released XX.04.20)
 * fix build with mkl (#229)
+* fix build with non-system libfftw (#234)
 
 ## Version 1.6 _SuperPelagia_ (released 17.04.20)
 * fix clang-10 warnings (#217)

--- a/include/votca/tools/eigen.h
+++ b/include/votca/tools/eigen.h
@@ -49,7 +49,6 @@
 #endif
 #include <Eigen/Eigen>
 #include <unsupported/Eigen/CXX11/Tensor>
-#include <unsupported/Eigen/FFT>
 #if (defined STRICT_GNUC) && GCC_VERSION > 70000
 #pragma GCC diagnostic pop
 #endif

--- a/src/libtools/crosscorrelate.cc
+++ b/src/libtools/crosscorrelate.cc
@@ -16,6 +16,9 @@
  */
 
 #include <votca/tools/crosscorrelate.h>
+#include <votca/tools/eigen.h>
+
+// include after eigen.h
 #include <unsupported/Eigen/FFT>
 
 namespace votca {

--- a/src/libtools/crosscorrelate.cc
+++ b/src/libtools/crosscorrelate.cc
@@ -16,6 +16,7 @@
  */
 
 #include <votca/tools/crosscorrelate.h>
+#include <unsupported/Eigen/FFT>
 
 namespace votca {
 namespace tools {


### PR DESCRIPTION
Non-system fftw will lead to a missing 'fftw.h' when building
excutables as fftw is only a private dependcies and hence the
fftw include path is missing. Don't include fft header in
eigen.h, so it won't get pull in for every executable.

Reported here:
https://groups.google.com/d/msg/votca/wFNG1mmKwSU/hOS1zplRDQAJ