### PR TITLE
inject defaults into calculators values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For more detailed information about the changes see the history of the [reposito
 * rename WITH_RC_FILES to INSTALL_RC_FILES (#236)
 * check calculator input options (#232, #233)
 * allow calculator choices to be a list (#239)
-* Inject defaults into calculator values
+* inject defaults into calculator values (#241)
 
 ## Version 1.6.1 (released XX.04.20)
 * fix build with mkl (#229)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For more detailed information about the changes see the history of the [reposito
 * rename WITH_RC_FILES to INSTALL_RC_FILES (#236)
 * check calculator input options (#232, #233)
 * allow calculator choices to be a list (#239)
+* Inject defaults into calculator values
 
 ## Version 1.6.1 (released XX.04.20)
 * fix build with mkl (#229)

--- a/include/votca/tools/calculator.h
+++ b/include/votca/tools/calculator.h
@@ -101,6 +101,7 @@ class Calculator {
   Property LoadDefaultsAndUpdateWithUserOptions(const std::string package,
                                                 const Property &user_options) {
     Property defaults = LoadDefaults(package);
+    InjectDefaultsAsValues(defaults);
     UpdateWithUserOptions(defaults, user_options);
     RecursivelyCheckOptions(defaults);
     return defaults;
@@ -111,6 +112,8 @@ class Calculator {
   bool _maverick;
 
   void OverwriteDefaultsWithUserInput(const Property &p, Property &defaults);
+  // Copy the defaults into the value
+  static void InjectDefaultsAsValues(Property &defaults);
   static void RecursivelyCheckOptions(const Property &prop);
   static bool IsValidOption(const Property &p,
                             const std::vector<std::string> &choices);

--- a/src/tests/test_calculator.cc
+++ b/src/tests/test_calculator.cc
@@ -46,12 +46,12 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       std::ofstream defaults("calculators/xml/testcalc.xml");
       defaults << "<options>\n"
                << "<testcalc>\n"
-               << "<option0 choices=\"foo,bar\">foo</option0>\n"
-               << "<option1 choices=\"int+\">0</option1>\n"
-               << "<option2 choices=\"float\">-3.141592</option2>\n"
-               << "<option4 choices=\"float+\">3.141592</option4>\n"
-               << "<option5 choices=\"bool\">true</option5>\n"
-               << "<option6 choices=\"foo,bar,baz,qux\">[foo,qux]</option6>\n"
+               << "<option0 default=\"foo\" choices=\"foo,bar\"></option0>\n"
+               << "<option1 default=\"0\" choices=\"int+\"></option1>\n"
+               << "<option2 default=\"-3.141592\" choices=\"float\"></option2>\n"
+               << "<option4 default=\"3.141592\" choices=\"float+\"></option4>\n"
+               << "<option5 default=\"true\" choices=\"bool\"></option5>\n"
+               << "<option6 default=\"foo,qux\" choices=\"[foo,bar,baz,qux]\"></option6>\n"
                << "</testcalc>\n"
                << "</options>";
       defaults.close();
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(test_choices) {
   test3.SetOption("<option3 choices=\"int\">3.14</option3>\n");
   test4.SetOption("<option4 choices=\"int+\">-2</option4>\n");
   test5.SetOption("<option5 choices=\"float+\">-3.14</option5>\n");
-  test6.SetOption("<option6 choices=\"foo,bar,qux\">[tux]</option6>\n");
+  test6.SetOption("<option6 choices=\"[foo,bar,qux]\">tux</option6>\n");
 
   BOOST_CHECK_THROW(test1.Initialize(user_options), std::runtime_error);
   BOOST_CHECK_THROW(test2.Initialize(user_options), std::runtime_error);

--- a/src/tests/test_calculator.cc
+++ b/src/tests/test_calculator.cc
@@ -44,16 +44,20 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       boost::filesystem::create_directory(dir);
 
       std::ofstream defaults("calculators/xml/testcalc.xml");
-      defaults << "<options>\n"
-               << "<testcalc>\n"
-               << "<option0 default=\"foo\" choices=\"foo,bar\"></option0>\n"
-               << "<option1 default=\"0\" choices=\"int+\"></option1>\n"
-               << "<option2 default=\"-3.141592\" choices=\"float\"></option2>\n"
-               << "<option4 default=\"3.141592\" choices=\"float+\"></option4>\n"
-               << "<option5 default=\"true\" choices=\"bool\"></option5>\n"
-               << "<option6 default=\"foo,qux\" choices=\"[foo,bar,baz,qux]\"></option6>\n"
-               << "</testcalc>\n"
-               << "</options>";
+      defaults
+          << "<options>\n"
+          << "<testcalc>\n"
+          << "<option0 default=\"foo\" choices=\"foo,bar\"></option0>\n"
+          << "<option1 default=\"0\" choices=\"int+\"></option1>\n"
+          << "<option2 default=\"-3.141592\" choices=\"float\"></option2>\n"
+          << "<option4 default=\"3.141592\" choices=\"float+\"></option4>\n"
+          << "<option5 default=\"true\" choices=\"bool\"></option5>\n"
+          << "<option6 default=\"1,3\" choices=\"[1,2,3]\"></option6>\n"
+          << "<option7>\n"
+          << "<option71 default=\"none\" choices=\"some,none\"></option71>\n"
+          << "</option7>\n"
+          << "</testcalc>\n"
+          << "</options>";
       defaults.close();
 
       // Load and check the options
@@ -66,12 +70,17 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       std::string prop3 = final_opt.get("option3.nested").as<std::string>();
       double prop4 = final_opt.get("option4").as<double>();
       bool prop5 = final_opt.get("option5").as<bool>();
+      std::string prop6 = final_opt.get("option6").as<std::string>();
+      const tools::Property &prop7 = final_opt.get("option7");
+      std::string prop71 = prop7.get("option71").as<std::string>();
       BOOST_CHECK_EQUAL(prop0, "foo");
       BOOST_CHECK_EQUAL(prop1, 42);
       BOOST_CHECK_CLOSE(prop2, -3.141592, 0.00001);
       BOOST_CHECK_EQUAL(prop3, "nested_value");
       BOOST_CHECK_CLOSE(prop4, 3.141592, 0.00001);
       BOOST_CHECK_EQUAL(prop5, true);
+      BOOST_CHECK_EQUAL(prop6, "1,3");
+      BOOST_CHECK_EQUAL(prop71, "none");
     }
   };
 


### PR DESCRIPTION
##  Proposed changes
1) Currently, in the XML files containing the `Calculators` options, the default and the option value are the same, but the defaults are only used for documentation purposes. In this PR we change that behaviour but allowing the XML to only define the defaults, leaving empty the values. A new `Calculator::InjectDefaultsAsValues` has been implemented to fill in the values.

2) We want to allow the options to take a single value out of a choice set, for example:
```
<option1 default="foo" choices="foo, bar"></option1>
```
But we also want to allow for the options to take multiple options out of multiple choices. The following syntax has been implemented for this case:
```
<option2 default="foo, qux" choices="[foo, bar, qux]"></option1>
```
 Notice the brackets in the `choices` attribute.

