### PR TITLE
update option only if new value is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For more detailed information about the changes see the history of the [reposito
 * check calculator input options (#232, #233)
 * allow calculator choices to be a list (#239)
 * inject defaults into calculator values (#241)
+* fixed bug introduced by defaults injection (#241)
 
 ## Version 1.6.1 (released XX.04.20)
 * fix build with mkl (#229)

--- a/include/votca/tools/calculator.h
+++ b/include/votca/tools/calculator.h
@@ -102,7 +102,9 @@ class Calculator {
                                                 const Property &user_options) {
     Property defaults = LoadDefaults(package);
     InjectDefaultsAsValues(defaults);
-    UpdateWithUserOptions(defaults, user_options);
+    Property user_options_with_defaults = user_options;
+    InjectDefaultsAsValues(user_options_with_defaults);
+    UpdateWithUserOptions(defaults, user_options_with_defaults);
     RecursivelyCheckOptions(defaults);
     return defaults;
   }

--- a/src/libtools/calculator.cc
+++ b/src/libtools/calculator.cc
@@ -68,9 +68,9 @@ void Calculator::OverwriteDefaultsWithUserInput(const Property &p,
         Property &new_prop = defaults.add(prop.name(), "");
         new_prop = prop;
       }
-    } else if (defaults.exists(prop.name())) {
+    } else if (defaults.exists(prop.name()) && (prop.value() != "")) {
       defaults.set(prop.name(), prop.value());
-    } else {
+    } else if (prop.value() != "") {
       defaults.add(prop.name(), prop.value());
     }
   }

--- a/src/libtools/calculator.cc
+++ b/src/libtools/calculator.cc
@@ -165,7 +165,7 @@ void Calculator::InjectDefaultsAsValues(Property &defaults) {
     if (prop.HasChildren()) {
       InjectDefaultsAsValues(prop);
     } else {
-      if (prop.hasAttribute("default")) {
+      if (prop.hasAttribute("default") && (prop.value() == "")) {
         prop.set(".", prop.getAttribute<std::string>("default"));
       }
     }

--- a/src/tests/test_calculator.cc
+++ b/src/tests/test_calculator.cc
@@ -56,6 +56,7 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
           << "<option7>\n"
           << "<option71 default=\"none\" choices=\"some,none\"></option71>\n"
           << "</option7>\n"
+          << "<option8 default=\"8\" choices=\"int+\"></option8>\n"
           << "</testcalc>\n"
           << "</options>";
       defaults.close();
@@ -73,7 +74,7 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       std::string prop6 = final_opt.get("option6").as<std::string>();
       const tools::Property &prop7 = final_opt.get("option7");
       std::string prop71 = prop7.get("option71").as<std::string>();
-      Index prop8 = final_opt.get("option8").as<Index>();
+      Index prop9 = final_opt.get("option9").as<Index>();
       BOOST_CHECK_EQUAL(prop0, "foo");
       BOOST_CHECK_EQUAL(prop1, 42);
       BOOST_CHECK_CLOSE(prop2, -3.141592, 0.00001);
@@ -83,6 +84,7 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       BOOST_CHECK_EQUAL(prop6, "1,3");
       BOOST_CHECK_EQUAL(prop71, "none");
       BOOST_CHECK_EQUAL(prop8, 8);
+      BOOST_CHECK_EQUAL(prop9, 9);
     }
   };
 
@@ -99,7 +101,8 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
   opt_test.add("option1", "42");
   tools::Property &new_prop = opt_test.add("option3", "");
   new_prop.add("nested", "nested_value");
-  new_prop = opt_test.add("option8", "8");
+  opt_test.add("option8", "");
+  opt_test.add("option9", "9");
 
   TestCalc test_calc;
   test_calc.Initialize(user_options);

--- a/src/tests/test_calculator.cc
+++ b/src/tests/test_calculator.cc
@@ -74,6 +74,7 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       std::string prop6 = final_opt.get("option6").as<std::string>();
       const tools::Property &prop7 = final_opt.get("option7");
       std::string prop71 = prop7.get("option71").as<std::string>();
+      Index prop8 = final_opt.get("option8").as<Index>();
       Index prop9 = final_opt.get("option9").as<Index>();
       BOOST_CHECK_EQUAL(prop0, "foo");
       BOOST_CHECK_EQUAL(prop1, 42);

--- a/src/tests/test_calculator.cc
+++ b/src/tests/test_calculator.cc
@@ -73,6 +73,7 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       std::string prop6 = final_opt.get("option6").as<std::string>();
       const tools::Property &prop7 = final_opt.get("option7");
       std::string prop71 = prop7.get("option71").as<std::string>();
+      Index prop8 = final_opt.get("option8").as<Index>();
       BOOST_CHECK_EQUAL(prop0, "foo");
       BOOST_CHECK_EQUAL(prop1, 42);
       BOOST_CHECK_CLOSE(prop2, -3.141592, 0.00001);
@@ -81,6 +82,7 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
       BOOST_CHECK_EQUAL(prop5, true);
       BOOST_CHECK_EQUAL(prop6, "1,3");
       BOOST_CHECK_EQUAL(prop71, "none");
+      BOOST_CHECK_EQUAL(prop8, 8);
     }
   };
 
@@ -97,6 +99,7 @@ BOOST_AUTO_TEST_CASE(load_defaults_test) {
   opt_test.add("option1", "42");
   tools::Property &new_prop = opt_test.add("option3", "");
   new_prop.add("nested", "nested_value");
+  new_prop = opt_test.add("option8", "8");
 
   TestCalc test_calc;
   test_calc.Initialize(user_options);

--- a/src/tests/test_calculator.cc
+++ b/src/tests/test_calculator.cc
@@ -153,13 +153,14 @@ BOOST_AUTO_TEST_CASE(test_choices) {
   tools::Property &opt = user_options.add("options", "");
   opt.add("testchoices", "");
 
-  TestChoices test1, test2, test3, test4, test5, test6;
+  TestChoices test1, test2, test3, test4, test5, test6, test7;
   test1.SetOption("<option1 choices=\"foo, bar, baz, qux\">boom</option1>\n");
   test2.SetOption("<option2 choices =\"float\">some</option2>\n");
   test3.SetOption("<option3 choices=\"int\">3.14</option3>\n");
   test4.SetOption("<option4 choices=\"int+\">-2</option4>\n");
   test5.SetOption("<option5 choices=\"float+\">-3.14</option5>\n");
   test6.SetOption("<option6 choices=\"[foo,bar,qux]\">tux</option6>\n");
+  test7.SetOption("<option7 choices=\"float+\"></option7>\n");
 
   BOOST_CHECK_THROW(test1.Initialize(user_options), std::runtime_error);
   BOOST_CHECK_THROW(test2.Initialize(user_options), std::runtime_error);
@@ -167,6 +168,7 @@ BOOST_AUTO_TEST_CASE(test_choices) {
   BOOST_CHECK_THROW(test4.Initialize(user_options), std::runtime_error);
   BOOST_CHECK_THROW(test5.Initialize(user_options), std::runtime_error);
   BOOST_CHECK_THROW(test6.Initialize(user_options), std::runtime_error);
+  BOOST_CHECK_THROW(test7.Initialize(user_options), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Fixed bug 
Following the new standard proposed in #241, only the `default` attribute contains information and the values are empty for the default `XML` files. When merging the `default` options with the `user` options, some of the user's values may be empty, resulting in a `Property` object that contains some empty values even though they have a well-defined default.

### Proposed changes
Only overwrite the default values if the `user input` is non-empty.