### PR TITLE
For/stable/joshua s brown fix abs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ For more detailed information about the changes see the history of the [reposito
 * fix build with mkl (#229)
 * fix build with non-system libfftw (#234)
 * fix CI on Ubuntu-20.04 (#237)
+* fix bug related to calling c abs instead of c++ fabs (#248)
 
 ## Version 1.6 _SuperPelagia_ (released 17.04.20)
 * fix clang-10 warnings (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ For more detailed information about the changes see the history of the [reposito
 * fix build with non-system libfftw (#234)
 * fix CI on Ubuntu-20.04 (#237)
 * fix bug related to calling c abs instead of c++ fabs (#248)
+* updated floating point comparison to use boost epsilon error (#248)
+* promoted boost version from 1.53 to 1.63 (#248)
 
 ## Version 1.6 _SuperPelagia_ (released 17.04.20)
 * fix clang-10 warnings (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For more detailed information about the changes see the history of the [reposito
 * fix bug related to calling c abs instead of c++ fabs (#248)
 * updated floating point comparison to use boost epsilon error (#248)
 * promoted boost version from 1.53 to 1.63 (#248)
+* fix compile error in structure parameters by adding hash function (#248)
 
 ## Version 1.6 _SuperPelagia_ (released 17.04.20)
 * fix clang-10 warnings (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ For more detailed information about the changes see the history of the [reposito
 * fix build with non-system libfftw (#234)
 * fix CI on Ubuntu-20.04 (#237)
 * fix bug related to calling c abs instead of c++ fabs (#248)
-* updated floating point comparison to use boost epsilon error (#248)
-* promoted boost version from 1.53 to 1.63 (#248)
+* updated floating point comparison in akimaspline.h (#248)
 * fix compile error in structure parameters by adding hash function (#248)
 
 ## Version 1.6 _SuperPelagia_ (released 17.04.20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
 find_package(Threads REQUIRED)
 
-find_package(Boost 1.63.0 REQUIRED COMPONENTS program_options filesystem system )
+find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options filesystem system )
 
 option(BUILD_MANPAGES "Build manpages (might lead to problem on system without rpath" ON)
 #define this target here, so that individual man pages can append to it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 
 find_package(Threads REQUIRED)
 
-find_package(Boost 1.53.0 REQUIRED COMPONENTS program_options filesystem system )
+find_package(Boost 1.63.0 REQUIRED COMPONENTS program_options filesystem system )
 
 option(BUILD_MANPAGES "Build manpages (might lead to problem on system without rpath" ON)
 #define this target here, so that individual man pages can append to it.

--- a/include/votca/tools/akimaspline.h
+++ b/include/votca/tools/akimaspline.h
@@ -21,6 +21,7 @@
 #include "spline.h"
 #include <iostream>
 #include <votca/tools/eigen.h>
+#include <boost/math/special_functions/relative_difference.hpp>
 
 namespace votca {
 namespace tools {
@@ -95,7 +96,7 @@ inline double AkimaSpline::CalculateDerivative(double r) {
 
 inline double AkimaSpline::getSlope(double m1, double m2, double m3,
                                     double m4) {
-  if ((m1 == m2) && (m3 == m4)) {
+  if (boost::math::epsilon_difference(m1, m2) && boost::math::epsilon_difference(m3, m4)) {
     return (m2 + m3) / 2.0;
   } else {
     return (std::fabs(m4 - m3) * m2 + std::fabs(m2 - m1) * m3) /

--- a/include/votca/tools/akimaspline.h
+++ b/include/votca/tools/akimaspline.h
@@ -18,8 +18,8 @@
 #ifndef __VOTCA_TOOLS_AKIMASPLINE_H
 #define __VOTCA_TOOLS_AKIMASPLINE_H
 
+#include "floatingpointcomparison.h"
 #include "spline.h"
-#include <boost/math/special_functions/relative_difference.hpp>
 #include <iostream>
 #include <votca/tools/eigen.h>
 
@@ -96,8 +96,8 @@ inline double AkimaSpline::CalculateDerivative(double r) {
 
 inline double AkimaSpline::getSlope(double m1, double m2, double m3,
                                     double m4) {
-  if (boost::math::epsilon_difference(m1, m2) < 1E-15 &&
-      boost::math::epsilon_difference(m3, m4) < 1E-15) {
+  if (isApproximatelyEqual(m1, m2, 1E-15) &&
+      isApproximatelyEqual(m3, m4, 1E-15)) {
     return (m2 + m3) / 2.0;
   } else {
     return (std::fabs(m4 - m3) * m2 + std::fabs(m2 - m1) * m3) /

--- a/include/votca/tools/akimaspline.h
+++ b/include/votca/tools/akimaspline.h
@@ -98,8 +98,8 @@ inline double AkimaSpline::getSlope(double m1, double m2, double m3,
   if ((m1 == m2) && (m3 == m4)) {
     return (m2 + m3) / 2.0;
   } else {
-    return (std::abs(m4 - m3) * m2 + std::abs(m2 - m1) * m3) /
-           (std::abs(m4 - m3) + std::abs(m2 - m1));
+    return (std::fabs(m4 - m3) * m2 + std::fabs(m2 - m1) * m3) /
+           (std::fabs(m4 - m3) + std::fabs(m2 - m1));
   }
 }
 

--- a/include/votca/tools/akimaspline.h
+++ b/include/votca/tools/akimaspline.h
@@ -96,7 +96,7 @@ inline double AkimaSpline::CalculateDerivative(double r) {
 
 inline double AkimaSpline::getSlope(double m1, double m2, double m3,
                                     double m4) {
-  if (boost::math::epsilon_difference(m1, m2) && boost::math::epsilon_difference(m3, m4)) {
+  if (boost::math::epsilon_difference(m1, m2) < 1E-15 && boost::math::epsilon_difference(m3, m4) < 1E-15) {
     return (m2 + m3) / 2.0;
   } else {
     return (std::fabs(m4 - m3) * m2 + std::fabs(m2 - m1) * m3) /

--- a/include/votca/tools/floatingpointcomparison.h
+++ b/include/votca/tools/floatingpointcomparison.h
@@ -33,6 +33,10 @@
  * https://stackoverflow.com/questions/17333/what-is-the-most-effective-way-for-float-and-double-comparison
  * user ShitalShal
  */
+
+// Standard includes
+#include <cstdlib>
+
 namespace votca {
 namespace tools {
 

--- a/include/votca/tools/structureparameters.h
+++ b/include/votca/tools/structureparameters.h
@@ -105,7 +105,7 @@ class StructureParameters {
   T get(const StructureParameter parameter) const;
 
  private:
-  std::unordered_map<StructureParameter, boost::any> parameters;
+  std::unordered_map<StructureParameter, boost::any, std::hash<int>> parameters;
 };
 
 void StructureParameters::set(const StructureParameter parameter,

--- a/src/libtools/elements.cc
+++ b/src/libtools/elements.cc
@@ -193,11 +193,11 @@ std::pair<std::string, double> Elements::findShortNameOfElementClosestInMass_(
     _filled_Mass = true;
   }
   std::string eleShort = "H";
-  double diff = std::abs(mass - _Mass[eleShort]);
+  double diff = std::fabs(mass - _Mass[eleShort]);
   for (const auto& ele_pr : _Mass) {
-    if (abs(ele_pr.second - mass) < diff) {
+    if (std::fabs(ele_pr.second - mass) < diff) {
       eleShort = ele_pr.first;
-      diff = abs(ele_pr.second - mass);
+      diff = std::fabs(ele_pr.second - mass);
     }
   }
   return std::pair<std::string, double>(eleShort, diff);

--- a/src/libtools/histogram.cc
+++ b/src/libtools/histogram.cc
@@ -76,7 +76,7 @@ void Histogram::ProcessData(DataCollection<double>::selection* data) {
   if (_options._scale == "bond") {
     for (size_t i = 0; i < _pdf.size(); ++i) {
       double r = _min + _interval * (double)i;
-      if (abs(r) < 1e-10) {
+      if (fabs(r) < 1e-10) {
         r = _min + _interval * (double)(i + 1);
         _pdf[i] = _pdf[i + 1];
       }
@@ -86,7 +86,7 @@ void Histogram::ProcessData(DataCollection<double>::selection* data) {
     for (size_t i = 0; i < _pdf.size(); ++i) {
       double alpha = _min + _interval * (double)i;
       double sa = sin(alpha);
-      if (abs(sa) < 1e-5) {
+      if (fabs(sa) < 1e-5) {
         if (i < _pdf.size() - 1) {
           alpha = _min + _interval * (double)(i + 1);
           _pdf[i] = _pdf[i + 1] / sin(alpha);

--- a/src/libtools/histogram.cc
+++ b/src/libtools/histogram.cc
@@ -76,7 +76,7 @@ void Histogram::ProcessData(DataCollection<double>::selection* data) {
   if (_options._scale == "bond") {
     for (size_t i = 0; i < _pdf.size(); ++i) {
       double r = _min + _interval * (double)i;
-      if (fabs(r) < 1e-10) {
+      if (std::fabs(r) < 1e-10) {
         r = _min + _interval * (double)(i + 1);
         _pdf[i] = _pdf[i + 1];
       }
@@ -86,7 +86,7 @@ void Histogram::ProcessData(DataCollection<double>::selection* data) {
     for (size_t i = 0; i < _pdf.size(); ++i) {
       double alpha = _min + _interval * (double)i;
       double sa = sin(alpha);
-      if (fabs(sa) < 1e-5) {
+      if (std::fabs(sa) < 1e-5) {
         if (i < _pdf.size() - 1) {
           alpha = _min + _interval * (double)(i + 1);
           _pdf[i] = _pdf[i + 1] / sin(alpha);

--- a/src/tests/test_structureparameters.cc
+++ b/src/tests/test_structureparameters.cc
@@ -22,7 +22,6 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <string>
-#include <unordered_map>
 #include <vector>
 #include <votca/tools/types.h>
 using namespace std;


### PR DESCRIPTION
The wrong abs function was being used. Somewhere a c header was being included that was converting a double to int when calling abs. This was mitigated by using fabs.

The bug was discovered as a result in the lammps data reader in csg: https://github.com/votca/csg/issues/537