### PR TITLE
removed unused openmp define

### DIFF
--- a/include/votca/tools/votca_config.h.in
+++ b/include/votca/tools/votca_config.h.in
@@ -18,11 +18,6 @@
 #ifndef __VOTCA_TOOLS_VOTCA_CONFIG_H
 #define __VOTCA_TOOLS_VOTCA_CONFIG_H
 
-/* OpenMP */
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 /* Linear algebra packages */
 #cmakedefine MKL_FOUND
 


### PR DESCRIPTION
the openmp part is not used in tools, at least I think so. 
