### PR TITLE
removed global mkl from globals to clear up include structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For more detailed information about the changes see the history of the [reposito
 * add rel. compare to votca_compare (#143)
 * standardize header formatting (#246)
 * move CI to GitHub Ations (#251, #254, #256)
+* improve mkl detection (#257)
 
 ## Version 1.6.1 (released XX.04.20)
 * fix build with mkl (#229)

--- a/include/votca/tools/globals.h
+++ b/include/votca/tools/globals.h
@@ -21,9 +21,6 @@
 // Standard includes
 #include <string>
 
-// Local VOTCA includes
-#include "votca_config.h"
-
 namespace votca {
 
 struct Log {

--- a/src/libtools/globals.cc
+++ b/src/libtools/globals.cc
@@ -26,12 +26,6 @@ namespace tools {
 std::string globals::url = "http://www.votca.org";
 std::string globals::email = "devs@votca.org";
 
-#ifdef MKL_FOUND
-bool globals::VOTCA_MKL = true;
-#else
-bool globals::VOTCA_MKL = false;
-#endif
-
 std::string globals::man::option(".TP\n\\fB%1%\\fR\n%2%\n");
 
 std::string globals::man::header(".TH \"%1%\" 1 \"\" \"Version: %2%\"\n\n");


### PR DESCRIPTION
the function is not really reliable in detecting the xtp problem. Delete the whole variable because the include is problematic 