### PR TITLE
CI: do not build for master

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,8 +1,5 @@
 name: CI
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,8 @@ Version 1.7-dev
 -  make votca\_compare always executable in builddir (#244)
 -  add rel. compare to votca\_compare (#143)
 -  standardize header formatting (#246)
--  move CI to GitHub Ations (#251, #254, #256, #258, #260)
+-  move CI to GitHub Ations (#251, #254, #256, #258, #260,
+   #274)
 -  improve mkl detection (#257)
 -  clean up installed cmake find modules (#263)
 -  update codacy badge (#264)

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ You can contact the VOTCA Development Team at devs@votca.org.
    :target: https://www.codacy.com/gh/votca/tools?utm_source=github.com&utm_medium=referral&utm_content=votca/tools&utm_campaign=Badge_Grade
 .. |codecov| image:: https://codecov.io/gh/votca/tools/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/votca/tools
-.. |CI| image:: https://github.com/votca/tools/workflows/CI/badge.svg
-   :target: https://github.com/votca/tools/actions?query=branch%3Agithub_actions+workflow%3ACI
+.. |CI| image:: https://github.com/votca/votca/workflows/CI/badge.svg?branch=master
+   :target: https://github.com/votca/votca/actions?query=workflow%3ACI+branch%3Amaster
 .. |DOI| image:: https://zenodo.org/badge/23848711.svg
    :target: https://zenodo.org/badge/latestdoi/23848711


### PR DESCRIPTION
Not needs as this will be built on `votca/votca` immediately after each PR.