### PR TITLE
Help rst man

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Version 2022-dev
 -  remove tex and man output from app class (#329)
 -  fix example rst section (#327, #339)
 -  remove author and copyright from rst (#331)
--  fix rst warnings (#334)
+-  fix rst warnings (#334, #346)
 -  export PYTHONPATH in VOTCARC (#340)
 -  drop csh support in VOTCARC (#342)
 

--- a/scripts/votca_help2doc.in
+++ b/scripts/votca_help2doc.in
@@ -135,6 +135,7 @@ def format_rst(sec: Data) -> str:
 OPTIONS
 *******
 .. highlight:: none
+
 ::
 """
     return f"""

--- a/scripts/votca_help2doc.in
+++ b/scripts/votca_help2doc.in
@@ -128,16 +128,26 @@ def format_options(options: str):
     return "\n".join(s)
 
 
-def format_rst(sec: Data) -> str:
-    """Format the section as RST."""
-    opts = "\n".join(f"  {x}" for x in sec.options.splitlines())
-    options_code_block = """
-OPTIONS
-*******
+def generate_code_block(name: str) -> str:
+    """Generate a code block section."""
+    return f"""
+{name}
+{'*' * len(name)}
 .. highlight:: none
 
 ::
+
 """
+
+
+def format_rst(sec: Data) -> str:
+    """Format the section as RST."""
+    opts = "\n".join(f"  {x}" for x in sec.options.splitlines())
+    examples = "\n".join(f"  {x}" for x in sec.examples.splitlines())
+
+    options_code_block = generate_code_block("OPTIONS")
+    examples_code_block = generate_code_block("EXAMPLES")
+
     return f"""
 NAME
 ****
@@ -154,7 +164,8 @@ DESCRIPTION
 ***********
 {sec.description}
 
-{sec.examples}
+{examples_code_block if examples else ""}
+{examples}
 
 {options_code_block if opts else ""}
 {opts}
@@ -208,7 +219,7 @@ def read_section_examples(lines: Iterable[str]) -> Tuple[str, str]:
     # extract example section
     examples = "\n  ".join(lines)
     if examples:
-        examples = "Examples:\n\n  " + examples
+        examples = "  " + examples
 
     return desc, examples
 

--- a/scripts/votca_help2doc.in
+++ b/scripts/votca_help2doc.in
@@ -58,6 +58,7 @@ class Data(NamedTuple):
     description: str
     examples: str
     options: str
+    usage: str
     authors: str = AUTHORS
     copyright: str = COPYRIGHT
 
@@ -91,6 +92,7 @@ def parse_help_message(msg: str, name: str) -> Data:
     # description and optional examples
     opts_lines, lines = take_until_options(lines)
     description, examples = read_section_examples(opts_lines)
+    description, usage = search_for_usage(description)
     # Options and optional examples
 
     if examples:
@@ -100,7 +102,18 @@ def parse_help_message(msg: str, name: str) -> Data:
 
     options = format_options(options)
 
-    return Data(name, description, examples, options)
+    return Data(name, description, examples, options, usage)
+
+
+def search_for_usage(desc: str) -> Tuple[str, str]:
+    """Search for an `usage:` declaration in the description."""
+    keywords = {u for u in {"Usage:", "usage:"} if u in desc}
+    if not keywords:
+        return desc, ""
+    else:
+        key = keywords.pop()
+        desc, usage = desc.split(key)
+        return desc, f"Usage:{usage}"
 
 
 def take_until_options(lines: Iterable[str]) -> Tuple[Iterable[str], Iterable[str]]:
@@ -159,6 +172,7 @@ SYNOPSIS
 
 **{sec.name}** [--help]
 
+{sec.usage}
 
 DESCRIPTION
 ***********

--- a/scripts/votca_help2doc.in
+++ b/scripts/votca_help2doc.in
@@ -113,8 +113,8 @@ def search_for_usage(desc: str) -> Tuple[str, str]:
         return desc, ""
     else:
         key = keywords.pop()
-        desc, usage = desc.split(key)
-        return desc, f"Usage:{usage}"
+        data = desc.split(key)
+        return data[0], ''.join([f'Usage:{d}' for d in data[1:]])
 
 
 def take_while_version(lines: Iterable[str]) -> Iterable[str]:
@@ -159,7 +159,6 @@ def generate_code_block(name: str) -> str:
 .. highlight:: none
 
 ::
-
 """
 
 

--- a/scripts/votca_help2doc.in
+++ b/scripts/votca_help2doc.in
@@ -87,8 +87,9 @@ def parse_help_message(msg: str, name: str) -> Data:
     lines = iter(msg.splitlines())
     # Votca logo
     take(lines, 6)
-    # Compilation info
-    list(itertools.takewhile(lambda x: x, lines))
+    # remove Compilation info
+    lines = take_while_version(lines)
+
     # description and optional examples
     opts_lines, lines = take_until_options(lines)
     description, examples = read_section_examples(opts_lines)
@@ -114,6 +115,15 @@ def search_for_usage(desc: str) -> Tuple[str, str]:
         key = keywords.pop()
         desc, usage = desc.split(key)
         return desc, f"Usage:{usage}"
+
+
+def take_while_version(lines: Iterable[str]) -> Iterable[str]:
+    """Remove the lines with version on it."""
+    value = next(lines)
+    if any(key in value for key in {"version", "bugs", "gromacs, 20"}):
+        return take_while_version(lines)
+    else:
+        return itertools.chain([value], lines)
 
 
 def take_until_options(lines: Iterable[str]) -> Tuple[Iterable[str], Iterable[str]]:


### PR DESCRIPTION
## Changes
* fix #346 

## Other warnings
@junghans  locally I can only see a remaining warning:
```
votca/build/sphinx/csg/csg_orientcorr.rst:19: WARNING: Definition list ends without a blank line; unexpected unindent.
```

That warning is due to the equation in the description:
```
Calculates the orientational correlation function
    <3/2*u(0)*u(r) - 1/2>
for a polymer melt, where u is the vector pointing along a bond and
r the distance between bond segments (centered on middle of bond).
```
Any suggestions about it?
