### PR TITLE
Joshua s brown/fix missing include

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Version 2022-dev
 -  fix rst warnings (#334, #346, #348)
 -  export PYTHONPATH in VOTCARC (#340)
 -  drop csh support in VOTCARC (#342)
+-  add missing cmath include (#351)
 
 Version 2021-rc.2 (released XX.01.21)
 =====================================

--- a/include/votca/tools/average.h
+++ b/include/votca/tools/average.h
@@ -18,6 +18,7 @@
 #ifndef VOTCA_TOOLS_AVERAGE_H
 #define VOTCA_TOOLS_AVERAGE_H
 
+// Standard includes
 #include <cmath>
 
 namespace votca {

--- a/include/votca/tools/average.h
+++ b/include/votca/tools/average.h
@@ -18,6 +18,8 @@
 #ifndef VOTCA_TOOLS_AVERAGE_H
 #define VOTCA_TOOLS_AVERAGE_H
 
+#include <cmath>
+
 namespace votca {
 namespace tools {
 


### PR DESCRIPTION
std::sqrt is used in average.h but cmath is not included this fixes the problem. 