### PR TITLE
Remove unused header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Version 2021-rc.2 (released XX.01.21)
 
 -  fix CI on rawhide (#336)
 -  add auto-cancel workflow to GitHub Actions (#343)
+-  remove unused ext/alloc_traits.h from tests (#354)
 
 Version 2021-rc.1 (released 15.01.21)
 =====================================

--- a/src/tests/test_graphalgorithm.cc
+++ b/src/tests/test_graphalgorithm.cc
@@ -33,7 +33,6 @@
 
 // Third party includes
 #include <boost/test/unit_test.hpp>
-#include <ext/alloc_traits.h>
 
 // Local VOTCA includes
 #include "votca/tools/edge.h"


### PR DESCRIPTION
Header unused and was causing problems for clang compilers as it was an extension specific to GNU compilers. 