### PR TITLE
Propery extensions

### DIFF
--- a/include/votca/tools/lexical_cast.h
+++ b/include/votca/tools/lexical_cast.h
@@ -39,7 +39,7 @@ inline Target lexical_cast(const Source &arg, const std::string &error) {
   try {
     return boost::lexical_cast<Target, Source>(arg);
   } catch (std::exception &) {
-    throw std::runtime_error("invaid type: " + error);
+    throw std::runtime_error("invalid type: " + error);
   }
 }
 

--- a/include/votca/tools/property.h
+++ b/include/votca/tools/property.h
@@ -20,6 +20,7 @@
 
 // Standard includes
 #include <cstdlib>
+#include <exception>
 #include <iostream>
 #include <list>
 #include <map>
@@ -274,7 +275,12 @@ template <typename T>
 inline T Property::as() const {
   std::string trimmed = _value;
   boost::trim(trimmed);
-  return convertFromString<T>(trimmed);
+  try {
+    return convertFromString<T>(trimmed);
+  } catch (std::runtime_error &e) {
+    throw std::runtime_error("Property with name '" + name() + "' in path '" +
+                             path() + "' and value :" + e.what());
+  }
 }
 
 template <typename T>

--- a/include/votca/tools/property.h
+++ b/include/votca/tools/property.h
@@ -256,21 +256,12 @@ class Property {
   static const Index IOindex;
 };
 
-// TO DO: write a better function for this!!!!
-template <>
-inline bool Property::as<bool>() const {
-  if (_value == "true" || _value == "TRUE" || _value == "1") {
-    return true;
-  } else if (_value == "false" || _value == "FALSE" || _value == "0") {
-    return false;
-  } else {
-    throw std::runtime_error(_value + " cannot be convert to bool.");
-  }
-}
 
 template <typename T>
 inline T Property::as() const {
-  return lexical_cast<T>(_value, "wrong type in " + _path + "." + _name + "\n");
+  std::string trimmed=_value;
+  boost::trim(trimmed);
+  return convertFromString<T>(trimmed);
 }
 
 template <typename T>
@@ -317,49 +308,11 @@ inline T Property::ifExistsAndinListReturnElseThrowRuntimeError(
   return result;
 }
 
-template <>
-inline std::string Property::as<std::string>() const {
-  std::string tmp(_value);
-  boost::trim(tmp);
-  return tmp;
-}
-
-template <>
-inline Eigen::VectorXd Property::as<Eigen::VectorXd>() const {
-  std::vector<double> tmp =
-      Tokenizer(as<std::string>(), " ,\n\t").ToVector<double>();
-  return Eigen::Map<Eigen::VectorXd>(tmp.data(), tmp.size());
-}
-
-template <>
-inline Eigen::Vector3d Property::as<Eigen::Vector3d>() const {
-  std::vector<double> tmp =
-      Tokenizer(as<std::string>(), " ,\n\t").ToVector<double>();
-
-  if (tmp.size() != 3) {
-    throw std::runtime_error("Vector has " + std::to_string(tmp.size()) +
-                             " instead of 3 entries");
-  }
-  return {tmp[0], tmp[1], tmp[2]};
-}
-
-template <>
-inline std::vector<Index> Property::as<std::vector<Index> >() const {
-  return Tokenizer(as<std::string>(), " ,\n\t").ToVector<Index>();
-}
-
-template <>
-inline std::vector<double> Property::as<std::vector<double> >() const {
-  return Tokenizer(as<std::string>(), " ,\n\t").ToVector<double>();
-}
-
 template <typename T>
 inline T Property::getAttribute(
     std::map<std::string, std::string>::const_iterator it) const {
   if (it != _attributes.end()) {
-    return lexical_cast<T>(it->second, "wrong type in attribute " + it->first +
-                                           " of element " + _path + "." +
-                                           _name + "\n");
+    return convertFromString<T>(it->second);
   } else {
     std::stringstream s;
     s << *this << std::endl;

--- a/include/votca/tools/property.h
+++ b/include/votca/tools/property.h
@@ -185,6 +185,26 @@ class Property {
   Index size() const { return Index(_properties.size()); }
 
   /**
+   * \brief deletes properties based on a key
+   * @param key
+   * @return returns number of properties removed
+   *
+   * This function tries to delete all properties specified by key separated
+   * by "." to step down hierarchy. If no property is
+   * found nothing happens. This invalidates pointers to all child properties.
+   */
+  Index deleteChildren(const std::string &key);
+  /**
+   * \brief deletes a child property
+   * @param pointer to child
+   *
+   * This function deletes a child of this property, specified by the pointer.
+   * Pointer must point to a valid child. This invalidates pointers to all child
+   * properties.
+   */
+  void deleteChild(iterator child_pointer);
+
+  /**
    * \brief return attribute as type
    *
    * returns an attribute after type conversion, e.g.
@@ -240,6 +260,10 @@ class Property {
   template <typename T>
   T getAttribute(const_AttributeIterator it) const;
 
+  void deleteAttribute(const std::string &attribute) {
+    _attributes.erase(attribute);
+  }
+
   void LoadFromXML(std::string filename);
 
   static Index getIOindex() { return IOindex; };
@@ -256,10 +280,9 @@ class Property {
   static const Index IOindex;
 };
 
-
 template <typename T>
 inline T Property::as() const {
-  std::string trimmed=_value;
+  std::string trimmed = _value;
   boost::trim(trimmed);
   return convertFromString<T>(trimmed);
 }

--- a/include/votca/tools/property.h
+++ b/include/votca/tools/property.h
@@ -185,24 +185,14 @@ class Property {
   Index size() const { return Index(_properties.size()); }
 
   /**
-   * \brief deletes properties based on a key
-   * @param key
-   * @return returns number of properties removed
-   *
-   * This function tries to delete all properties specified by key separated
-   * by "." to step down hierarchy. If no property is
-   * found nothing happens. This invalidates pointers to all child properties.
-   */
-  Index deleteChildren(const std::string &key);
-  /**
    * \brief deletes a child property
    * @param pointer to child
    *
    * This function deletes a child of this property, specified by the pointer.
-   * Pointer must point to a valid child. This invalidates pointers to all child
-   * properties.
+   * Pointer must point to a valid child. This invalidates pointers and
+   * references to all children.
    */
-  void deleteChild(iterator child_pointer);
+  void deleteChild(Property *child);
 
   /**
    * \brief return attribute as type
@@ -269,7 +259,7 @@ class Property {
   static Index getIOindex() { return IOindex; };
 
  private:
-  std::map<std::string, Index> _map;
+  std::map<std::string, std::vector<Index>> _map;
   std::map<std::string, std::string> _attributes;
   std::vector<Property> _properties;
 

--- a/include/votca/tools/tokenizer.h
+++ b/include/votca/tools/tokenizer.h
@@ -53,10 +53,8 @@ inline T convert_impl(const std::string &s, type<T>) {
 inline bool convert_impl(const std::string &s, type<bool>) {
   if (s == "true" || s == "TRUE" || s == "1") {
     return true;
-  } else if (s == "false" || s == "FALSE" || s == "0") {
+  } else{
     return false;
-  } else {
-    throw std::runtime_error(s + " cannot be converted to bool.");
   }
 }
 

--- a/include/votca/tools/tokenizer.h
+++ b/include/votca/tools/tokenizer.h
@@ -23,11 +23,44 @@
 #include <vector>
 
 // Third party includes
-#include <boost/lexical_cast.hpp>
+#include "eigen.h"
+#include "lexical_cast.h"
 #include <boost/tokenizer.hpp>
-
+#include <type_traits>
 namespace votca {
 namespace tools {
+
+namespace internal {
+
+template <typename T>
+struct type {};
+
+template <typename T,
+          typename std::enable_if_t<std::is_arithmetic<T>::value &&
+                                        !std::is_same<T, bool>::value,
+                                    bool> = true>
+inline T convert_impl(const std::string &s, type<T>) {
+  return lexical_cast<T>(s, "Cannot create arithmetic type from" + s);
+}
+
+template <typename T,
+          typename std::enable_if_t<
+              std::is_constructible<T, std::string>::value, bool> = true>
+inline T convert_impl(const std::string &s, type<T>) {
+  return T(s);
+}
+
+inline bool convert_impl(const std::string &s, type<bool>) {
+  if (s == "true" || s == "TRUE" || s == "1") {
+    return true;
+  } else if (s == "false" || s == "FALSE" || s == "0") {
+    return false;
+  } else {
+    throw std::runtime_error(s + " cannot be converted to bool.");
+  }
+}
+
+}  // namespace internal
 
 /**
  * \brief break string into words
@@ -50,8 +83,8 @@ class Tokenizer {
 
   Tokenizer(const std::string &str, const char *separators) : _str(str) {
     boost::char_separator<char> sep(separators);
-    tok = std::make_unique<boost::tokenizer<boost::char_separator<char>>>(_str,
-                                                                          sep);
+    tok_ = std::make_unique<boost::tokenizer<boost::char_separator<char>>>(_str,
+                                                                           sep);
   }
   Tokenizer(const std::string &str, const std::string &separators)
       : Tokenizer(str, separators.c_str()){};
@@ -60,12 +93,12 @@ class Tokenizer {
    * \brief iterator to first element
    * @return begin iterator
    */
-  iterator begin() { return tok->begin(); }
+  iterator begin() { return tok_->begin(); }
   /**
    * \brief end iterator
    * @return end iterator
    */
-  iterator end() { return tok->end(); }
+  iterator end() { return tok_->end(); }
 
   /**
    * \brief store all words in a vector of strings.
@@ -74,15 +107,20 @@ class Tokenizer {
    * This class appends all words to a vector of strings.
    */
   void ToVector(std::vector<std::string> &v) {
-    for (iterator iter = begin(); iter != end(); ++iter) {
-      v.push_back(*iter);
+    for (auto &seg : *this) {
+      v.push_back(seg);
     }
   }
 
-  std::vector<std::string> ToVector() {
-    std::vector<std::string> result;
-    for (iterator iter = begin(); iter != end(); ++iter) {
-      result.push_back(*iter);
+  /**
+   * \brief store all words in a vector of type T, does type conversion.
+   * @return storage vector
+   */
+  template <class T = std::string>
+  std::vector<T> ToVector() {
+    std::vector<T> result;
+    for (auto &seg : *this) {
+      result.push_back(internal::convert_impl(seg, internal::type<T>{}));
     }
     return result;
   }
@@ -107,7 +145,7 @@ class Tokenizer {
   }
 
  private:
-  std::unique_ptr<boost::tokenizer<boost::char_separator<char>>> tok;
+  std::unique_ptr<boost::tokenizer<boost::char_separator<char>>> tok_;
   std::string _str;
 };
 
@@ -115,6 +153,38 @@ class Tokenizer {
 // &quot;bl?h.*&quot; etc. This is good for file globbing or to match hostmasks.
 int wildcmp(const char *wild, const char *string);
 int wildcmp(const std::string &wild, const std::string &string);
+
+namespace internal {
+
+template <class T>
+inline std::vector<T> convert_impl(const std::string &s, type<std::vector<T>>) {
+  return Tokenizer(s, " ,\n\t").ToVector<T>();
+}
+
+template <class T>
+inline Eigen::Matrix<T, Eigen::Dynamic, 1> convert_impl(
+    const std::string &s, type<Eigen::Matrix<T, Eigen::Dynamic, 1>>) {
+  std::vector<T> tmp = convert_impl(s, type<std::vector<T>>{});
+  return Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>>(tmp.data(),
+                                                         tmp.size());
+}
+
+template <class T>
+inline Eigen::Matrix<T, 3, 1> convert_impl(const std::string &s,
+                                           type<Eigen::Matrix<T, 3, 1>>) {
+  std::vector<T> tmp = convert_impl(s, type<std::vector<T>>{});
+  if (tmp.size() != 3) {
+    throw std::runtime_error("Vector has " + std::to_string(tmp.size()) +
+                             " instead of 3 entries");
+  }
+  return {tmp[0], tmp[1], tmp[2]};
+}
+}  // namespace internal
+
+template <class T>
+T convertFromString(const std::string &s) {
+  return internal::convert_impl(s, internal::type<T>{});
+}
 
 }  // namespace tools
 }  // namespace votca

--- a/include/votca/tools/tokenizer.h
+++ b/include/votca/tools/tokenizer.h
@@ -53,7 +53,7 @@ inline T convert_impl(const std::string &s, type<T>) {
 inline bool convert_impl(const std::string &s, type<bool>) {
   if (s == "true" || s == "TRUE" || s == "1") {
     return true;
-  } else{
+  } else {
     return false;
   }
 }

--- a/src/libtools/calculator.cc
+++ b/src/libtools/calculator.cc
@@ -78,7 +78,7 @@ std::vector<std::string> Calculator::GetPropertyChoices(const Property &p) {
     if (start_bracket != std::string::npos) {
       std::size_t end_bracket = att.find(']');
       att = att.substr(start_bracket + 1, end_bracket - start_bracket - 1);
-    };
+    }
     return Tokenizer{att, " ,"}.ToVector();
   } else {
     return {""};

--- a/src/libtools/calculator.cc
+++ b/src/libtools/calculator.cc
@@ -78,8 +78,8 @@ std::vector<std::string> Calculator::GetPropertyChoices(const Property &p) {
       std::size_t end_bracket = att.find(']');
       att = att.substr(start_bracket + 1, end_bracket - start_bracket - 1);
     }
-    Tokenizer tok{att, " ,"};
-    return tok.ToVector();
+    ;
+    return Tokenizer{att, " ,"}.ToVector();
   } else {
     return {""};
   }

--- a/src/libtools/calculator.cc
+++ b/src/libtools/calculator.cc
@@ -134,7 +134,7 @@ bool Calculator::IsValidOption(const Property &prop,
   } else {
     std::string value = prop.as<std::string>();
     std::string att = prop.getAttribute<std::string>("choices");
-    bool has_brackets= att.find('[') != std::string::npos;
+    bool has_brackets = att.find('[') != std::string::npos;
     if (!has_brackets) {
       // There is a single choice out of multiple default valid choices
       is_valid = std::find(std::cbegin(choices), std::cend(choices), value) !=

--- a/src/libtools/property.cc
+++ b/src/libtools/property.cc
@@ -16,10 +16,12 @@
  */
 
 // Standard includes
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <stack>
 #include <stdexcept>
 #include <string>
@@ -50,7 +52,7 @@ const Property &Property::get(const string &key) const {
   }
 
   const Property *p;
-  map<string, Index>::const_iterator iter;
+  map<string, std::vector<Index>>::const_iterator iter;
   if (*n == "") {
     p = this;
   } else {
@@ -58,7 +60,7 @@ const Property &Property::get(const string &key) const {
     if (iter == _map.end()) {
       throw std::runtime_error("property not found: " + key);
     }
-    p = &_properties[iter->second];
+    p = &_properties[iter->second.back()];
   }
   ++n;
   try {
@@ -73,6 +75,10 @@ const Property &Property::get(const string &key) const {
   return *p;
 }
 
+Property &Property::get(const string &key) {
+  return const_cast<Property &>(static_cast<const Property &>(*this).get(key));
+}
+
 Property &Property::set(const std::string &key, const std::string &value) {
   Property &p = get(key);
   p.value() = value;
@@ -85,7 +91,7 @@ Property &Property::add(const std::string &key, const std::string &value) {
     path = path + ".";
   }
   _properties.push_back(Property(key, value, path + _name));
-  _map[key] = Index(_properties.size()) - 1;
+  _map[key].push_back(Index(_properties.size()) - 1);
   return _properties.back();
 }
 
@@ -121,7 +127,7 @@ void FixPath(tools::Property &prop, std::string path) {
 void Property::add(const Property &other) {
 
   _properties.push_back(other);
-  _map[other.name()] = Index(_properties.size()) - 1;
+  _map[other.name()].push_back((_properties.size()) - 1);
 
   std::string path = _path;
   if (path != "") {
@@ -129,10 +135,6 @@ void Property::add(const Property &other) {
   }
   path += _name;
   FixPath(_properties.back(), path);
-}
-
-Property &Property::get(const string &key) {
-  return const_cast<Property &>(static_cast<const Property &>(*this).get(key));
 }
 
 Property &Property::getOradd(const std::string &key) {
@@ -185,9 +187,36 @@ std::vector<Property *> Property::Select(const string &filter) {
   return selection;
 }
 
-Index Property::deleteChildren(const std::string &key) { return 0; }
+void Property::deleteChild(Property *child) {
+  // only works for std::vector
+  ptrdiff_t index_of_child = std::distance(_properties.data(), child);
+  assert(&_properties[index_of_child] == child &&
+         "You changed the containertype for property, fix deleteChild");
+  const Property &prop = _properties[index_of_child];
+  std::vector<Index> &indices = _map.at(prop.name());
 
-void Property::deleteChild(iterator child_pointer) { return; }
+  //erase index from map, if only one element in indeces remove the tag
+  if (indices.size() == 1) {
+    _map.erase(prop.name());
+  } else {
+    indices.erase(std::remove(indices.begin(), indices.end(), index_of_child),
+                  indices.end());
+  }
+
+  // if child is not the last element we have to do two things, a) switch the
+  // child with the last element and b) update the index of the former last
+  // element
+  if (child != &_properties.back()) {
+    Index old_index = _properties.size() - 1;
+    std::vector<Index> &indices_last = _map.at(_properties.back().name());
+    auto place = std::find(indices_last.begin(), indices_last.end(), old_index);
+    *place = index_of_child;
+    std::swap(_properties[index_of_child], _properties.back());
+  } 
+  _properties.pop_back();
+
+  return;
+}
 
 static void start_hndl(void *data, const char *el, const char **attr) {
   stack<Property *> *property_stack =

--- a/src/libtools/property.cc
+++ b/src/libtools/property.cc
@@ -58,7 +58,7 @@ const Property &Property::get(const string &key) const {
     if (iter == _map.end()) {
       throw std::runtime_error("property not found: " + key);
     }
-    p = &_properties[((*iter).second)];
+    p = &_properties[iter->second];
   }
   ++n;
   try {
@@ -184,6 +184,10 @@ std::vector<Property *> Property::Select(const string &filter) {
   }
   return selection;
 }
+
+Index Property::deleteChildren(const std::string &key) { return 0; }
+
+void Property::deleteChild(iterator child_pointer) { return; }
 
 static void start_hndl(void *data, const char *el, const char **attr) {
   stack<Property *> *property_stack =

--- a/src/libtools/rangeparser.cc
+++ b/src/libtools/rangeparser.cc
@@ -42,7 +42,7 @@ void RangeParser::Parse(std::string str) {
 }
 
 void RangeParser::ParseBlock(std::string str) {
-  std::vector<std::string> toks=Tokenizer(str, ":").ToVector();
+  std::vector<std::string> toks = Tokenizer(str, ":").ToVector();
 
   block_t block;
   block._stride = 1;

--- a/src/libtools/rangeparser.cc
+++ b/src/libtools/rangeparser.cc
@@ -27,9 +27,7 @@
 namespace votca {
 namespace tools {
 
-RangeParser::RangeParser()
-    //: _has_begin(false) , _has_end(false)
-    = default;
+RangeParser::RangeParser() = default;
 
 void RangeParser::Parse(std::string str) {
   // remove all spaces in string
@@ -44,13 +42,11 @@ void RangeParser::Parse(std::string str) {
 }
 
 void RangeParser::ParseBlock(std::string str) {
-  Tokenizer tokenizer(str, ":");
-  std::vector<std::string> toks;
+  std::vector<std::string> toks=Tokenizer(str, ":").ToVector();
 
   block_t block;
   block._stride = 1;
 
-  tokenizer.ToVector(toks);
   if (toks.size() > 3 || toks.size() < 1) {
     throw std::runtime_error("invalid range");
   }

--- a/src/libtools/table.cc
+++ b/src/libtools/table.cc
@@ -109,9 +109,7 @@ istream &operator>>(istream &in, Table &t) {
     line = line.substr(0, line.find("@"));
 
     // tokenize string and put it to vector
-    Tokenizer tok(line, " \t");
-
-    vector<string> tokens = tok.ToVector();
+    vector<string> tokens = Tokenizer(line, " \t").ToVector();
 
     // skip empty lines
     if (tokens.size() == 0) {
@@ -148,9 +146,7 @@ istream &operator>>(istream &in, Table &t) {
     line = line.substr(0, line.find("@"));
 
     // tokenize string and put it to vector
-    Tokenizer tok(line, " \t");
-    vector<string> tokens;
-    tok.ToVector(tokens);
+    vector<string> tokens=Tokenizer(line, " \t").ToVector();
 
     // skip empty lines
     if (tokens.size() == 0) {

--- a/src/tests/test_property.cc
+++ b/src/tests/test_property.cc
@@ -161,4 +161,36 @@ BOOST_AUTO_TEST_CASE(addproperty) {
   BOOST_CHECK_EQUAL(one.get("two.goodbye").path(), "one.two");
 }
 
+BOOST_AUTO_TEST_CASE(attributes) {
+
+  Property two("two", "", "");
+  Property& good = two.add("goodbye", "4");
+  BOOST_CHECK(!good.hasAttributes());
+  good.setAttribute<int>("hello", 2);
+  BOOST_CHECK(good.hasAttribute("hello"));
+
+  BOOST_CHECK(good.hasAttributes());
+
+  good.deleteAttribute("hello");
+  BOOST_CHECK(!good.hasAttributes());
+}
+
+BOOST_AUTO_TEST_CASE(deleteproperty) {
+
+  Property two("two", "", "");
+  two.add("goodbye", "4");
+  two.add("goodbye", "3");
+  Property& bye=two.add("bye", "1");
+  bye.add("hello","5");
+  votca::Index del=two.deleteChildren("goodbye");
+  BOOST_CHECK(!two.exists("goodbye"));
+  BOOST_CHECK_EQUAL(del,2);
+  votca::Index del2=two.deleteChildren("bye.hello");
+  BOOST_CHECK(!bye.exists("hello"));
+  BOOST_CHECK_EQUAL(del2,1);
+
+  votca::Index del3=two.deleteChildren("a.b");
+  BOOST_CHECK_EQUAL(del3,0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_property.cc
+++ b/src/tests/test_property.cc
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_CASE(eigen_test) {
   BOOST_CHECK_THROW(prop.get("vec").as<Eigen::Vector3d>(), std::runtime_error);
 
   Property prop2;
-  prop.add("vec", "1 2 3");
-  Eigen::Vector3d result2 = prop.get("vec").as<Eigen::Vector3d>();
+  prop2.add("vec", "1 2 3");
+  Eigen::Vector3d result2 = prop2.get("vec").as<Eigen::Vector3d>();
   Eigen::Vector3d ref2{1, 2, 3};
   BOOST_CHECK_EQUAL(ref2.isApprox(result2, 0.0001), true);
 }
@@ -180,17 +180,19 @@ BOOST_AUTO_TEST_CASE(deleteproperty) {
   Property two("two", "", "");
   two.add("goodbye", "4");
   two.add("goodbye", "3");
-  Property& bye=two.add("bye", "1");
-  bye.add("hello","5");
-  votca::Index del=two.deleteChildren("goodbye");
-  BOOST_CHECK(!two.exists("goodbye"));
-  BOOST_CHECK_EQUAL(del,2);
-  votca::Index del2=two.deleteChildren("bye.hello");
-  BOOST_CHECK(!bye.exists("hello"));
-  BOOST_CHECK_EQUAL(del2,1);
+  Property& bye = two.add("bye", "1");
+  bye.add("hello", "5");
 
-  votca::Index del3=two.deleteChildren("a.b");
-  BOOST_CHECK_EQUAL(del3,0);
+  two.deleteChild(&bye);
+  BOOST_CHECK(!two.exists("bye"));
+  BOOST_CHECK(two.exists("goodbye"));
+
+  Property& goodbye1=two.get("goodbye");
+  two.deleteChild(&goodbye1);
+  // there is still another goodbye tag
+  BOOST_CHECK(two.exists("goodbye"));
+
 }
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_tokenizer.cc
+++ b/src/tests/test_tokenizer.cc
@@ -28,9 +28,17 @@
 
 // Local VOTCA includes
 #include "votca/tools/tokenizer.h"
+#include "votca/tools/types.h"
 
 using namespace std;
 using namespace votca::tools;
+
+class ConstructibleFromString {
+ public:
+  ConstructibleFromString(const std::string& a) : a_(a) {}
+
+  std::string a_;
+};
 
 BOOST_AUTO_TEST_SUITE(tokenizer_test)
 
@@ -60,6 +68,19 @@ BOOST_AUTO_TEST_CASE(tokenizer_test) {
   BOOST_CHECK_EQUAL(tok3.begin() == tok3.end(), false);
   std::vector<std::string> result3 = tok3.ToVector();
   BOOST_CHECK_EQUAL(result3[0], "hello");
+
+  votca::Index i = 0;
+  std::vector<std::string> result4{"blah", "ya"};
+  for (auto token : Tokenizer(str1, separators)) {
+    BOOST_CHECK_EQUAL(token, result4[i]);
+    i++;
+  }
+
+  string str4 = "1,2,3";
+  std::vector<int> r = Tokenizer(str4, separators).ToVector<int>();
+
+  std::vector<ConstructibleFromString> p =
+      Tokenizer(str4, separators).ToVector<ConstructibleFromString>();
 }
 
 BOOST_AUTO_TEST_CASE(wildcmp_test) {
@@ -121,5 +142,14 @@ BOOST_AUTO_TEST_CASE(wildcmp_test2) {
   out = wildcmp(wildcard4, potential_match3);
   BOOST_CHECK_EQUAL(out, 1);
 }
+
+BOOST_AUTO_TEST_CASE(fromstring) {
+
+BOOST_CHECK_EQUAL(convertFromString<int>("3"),3);
+BOOST_CHECK_EQUAL(convertFromString<bool>("true"),true);
+convertFromString<ConstructibleFromString>("true");
+
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_tokenizer.cc
+++ b/src/tests/test_tokenizer.cc
@@ -145,11 +145,15 @@ BOOST_AUTO_TEST_CASE(wildcmp_test2) {
 
 BOOST_AUTO_TEST_CASE(fromstring) {
 
-BOOST_CHECK_EQUAL(convertFromString<int>("3"),3);
-BOOST_CHECK_EQUAL(convertFromString<bool>("true"),true);
-convertFromString<ConstructibleFromString>("true");
+  BOOST_CHECK_EQUAL(convertFromString<int>("3"), 3);
+  BOOST_CHECK_EQUAL(convertFromString<bool>("true"), true);
+  convertFromString<ConstructibleFromString>("true");
 
+  std::vector<int> r = convertFromString<std::vector<int>>("3,4,5");
+
+  BOOST_CHECK((r == std::vector<int>{3, 4, 5}));
+  Eigen::Vector3i s = convertFromString<Eigen::Vector3i>("3,4,5");
+  BOOST_CHECK(s.isApprox(Eigen::Vector3i{3, 4, 5}));
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tools/votca_property.cc
+++ b/src/tools/votca_property.cc
@@ -51,7 +51,7 @@ class VotcaProperty final : public Application {
 
     AddProgramOptions()("file", po::value<string>(), "xml file to parse")(
         "format", po::value<string>(),
-        "output format [XML TXT TEX]")("level", po::value<votca::Index>(),
+        "output format [XML TXT]")("level", po::value<votca::Index>(),
                                        "output from this level ");
   };
 

--- a/src/tools/votca_property.cc
+++ b/src/tools/votca_property.cc
@@ -50,9 +50,8 @@ class VotcaProperty final : public Application {
     level = 1;
 
     AddProgramOptions()("file", po::value<string>(), "xml file to parse")(
-        "format", po::value<string>(),
-        "output format [XML TXT]")("level", po::value<votca::Index>(),
-                                   "output from this level ");
+        "format", po::value<string>(), "output format [XML TXT]")(
+        "level", po::value<votca::Index>(), "output from this level ");
   };
 
   bool EvaluateOptions() {

--- a/src/tools/votca_property.cc
+++ b/src/tools/votca_property.cc
@@ -50,8 +50,9 @@ class VotcaProperty final : public Application {
     level = 1;
 
     AddProgramOptions()("file", po::value<string>(), "xml file to parse")(
-        "format", po::value<string>(), "output format [XML TXT]")(
-        "level", po::value<votca::Index>(), "output from this level ");
+        "format", po::value<string>(),
+        "output format [XML TXT]")("level", po::value<votca::Index>(),
+                                   "output from this level ");
   };
 
   bool EvaluateOptions() {


### PR DESCRIPTION
Made the string to type conversion much more powerful. Now `as<type>()` can be `bool` any numeric type or any kind of object that is constructible from a string and also a `std::vector<T>` of any of the above mentioned types, also Eigen::VectorXd Eigen::VectorXf and Eigen::Vector3d and Eigen::Vector3f are supported. 

Furthermore you can now delete Attributes and Children, although the later invalidates all pointers to child nodes. 

If we wanted we could go back to use a std::list underneath, instead of a std::vector and then all references would be valid, but then large xml files would take ages to load.

