### PR TITLE
removed requirement for threading link library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Version 2022-dev
 -  removed eigenvalue algorithm, now done by eigen  (#352)
 -  Added N-DimVector (#360)
 -  properties can be removed and string conversion much improved (#365)
+-  fix finding MKL (#368)
 
 Version 2021.1 (released XX.03.21)
 ==================================

--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -376,7 +376,7 @@ find_package_handle_standard_args(MKL
   REQUIRED_VARS MKL_INCLUDE_DIR
                 MKL_Core_LINK_LIBRARY
                 MKL_Interface_LINK_LIBRARY
-                MKL_Threading_LINK_LIBRARY
+                #MKL_Threading_LINK_LIBRARY enabling this fails using the pre oneAPI library
                 MKL_ThreadLayer_LINK_LIBRARY)
 
 find_package_handle_standard_args(MKL_Static


### PR DESCRIPTION
At the moment MKL is not found properly. 

We should in general rethink if we want to require MKL to be found and disable MKL with a cmake option instead of searching for it silently like atm, because the CI will not pick it up. 